### PR TITLE
Release/0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.x
 
+### 0.1.2
+* More migration helpers and alternative syntax for nesting suites
+
 ### 0.1.x
 
 #### 0.1.1

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ This project consists of the following modules:
 * `fixturegen` introducing per-test fixture generation for TestBalloon without boilerplate
 
 > [!TIP]  
-> `freespec` and `fixturegen` are [modulated](https://github.com/a-sit-plus/modulator) into the `fixturegen-freespec` module, meaning that if you add the
+> `freespec` and `fixturegen` are [modulated](https://github.com/a-sit-plus/modulator) into the `fixturegen-freespec`
+> module, meaning that if you add the
 > `at.asitplus.modulator` gradle plugin to any project that uses both, you can automagically combine FreeSpec syntax
-> and per-test fixture generation! If you don't want to use modulator, you can just add the `at.asitplus.testballoon:fixturegen-freespec:$version`
+> and per-test fixture generation! If you don't want to use modulator, you can just add the
+`at.asitplus.testballoon:fixturegen-freespec:$version`
 > dependency manually to your project.
-
 
 ### FreeSpec
 
@@ -99,6 +100,11 @@ val aFreeSpecSuite by testSuite {
 }
 ```
 
+> [!NOTE]  
+> Running individual tests from the gutter is not (yet) possible, due to the intricacies of how code analysis works.
+> Hence, you must run the entire suite (but you can manually filter using wildcards).  
+> (You can, of course, just migrate off FreeSpec and use TestBalloon's native functions to create suites and tests.)
+
 ### Data-Driven Testing
 
 | Maven Coordinates | `at.asitplus.testballoon:datatest:$version` |
@@ -118,8 +124,21 @@ val aDataDrivenSuite by testSuite {
             //your test logic being run 16 times
         }
     }
+
+    //Alternative syntax for withDataSuites
+    // -> NOTE the minus ↙↙↙
+    withData(1, 2, 3, 4) - { number ->
+        withData("one", "two", "three", "four") { word ->
+            //your test logic being run 16 times
+        }
+    }
 }
 ```
+
+> [!NOTE]  
+> Running individual tests from the gutter is not possible, as the test suite structure and the names of
+> suites and tests are computed at runtime.
+> Hence, you must run the entire suite (but you can manually filter using wildcards)
 
 ### Property Testing
 
@@ -142,12 +161,25 @@ import io.kotest.property.arbitrary.uLong
 
 val propertySuite by testSuite {
     checkAllSuites(iterations = 100, Arb.byteArray(Arb.int(100, 200), Arb.byte())) { byteArray ->
-        checkAll(iterations = 1000, Arb.uLong()) { number ->
+        checkAll(iterations = 10, Arb.uLong()) { number ->
+            //test with byte arrays and number for fun and profit
+        }
+    }
+
+    //Alternative syntax for checkAllSuites
+    // --> NOTE THE MINUS HERE >->-->--------------------------------------↘↘↘
+    checkAll(iterations = 100, Arb.byteArray(Arb.int(100, 200), Arb.byte())) - { byteArray ->
+        checkAll(iterations = 10, Arb.uLong()) { number ->
             //test with byte arrays and number for fun and profit
         }
     }
 }
 ```
+
+> [!NOTE]  
+> Running individual tests from the gutter is not possible, as the test suite structure and the names of
+> suites and tests are computed at runtime.
+> Hence, you must run the entire suite (but you can manually filter using wildcards)
 
 ### Per-Test Fixture Generation
 
@@ -252,8 +284,8 @@ val aGeneratingSuite by testSuite {
     }.generatingFixtureFor {
         repeat(1000) {
             test("Generated test accessing restricted resources") {
-               //test `restrictedAction` across a wide age range 
-               //a thousand times to unveil the bug
+                //test `restrictedAction` across a wide age range 
+                //a thousand times to unveil the bug
             }
         }
     }
@@ -264,11 +296,8 @@ val aGeneratingSuite by testSuite {
 <details>
 <summary>Combining with FreeSpec</summary> 
 
-
 | Maven Coordinates (if not using [modulator](https://github.com/a-sit-plus/modulator)) | `at.asitplus.testballoon:fixturegen-freespec:$version` |
 |---------------------------------------------------------------------------------------|--------------------------------------------------------|
-
-
 
 ```kotlin
 import at.asitplus.testballoon.generatingFixtureFor //<- Look ma, only regular generatingFixtureFor import!

--- a/datatest/src/commonMain/kotlin/at/asitplus/test/TestBalloonDataTest.kt
+++ b/datatest/src/commonMain/kotlin/at/asitplus/test/TestBalloonDataTest.kt
@@ -2,7 +2,6 @@ package at.asitplus.testballoon
 
 import de.infix.testBalloon.framework.core.TestConfig
 import de.infix.testBalloon.framework.core.TestSuite
-import de.infix.testBalloon.framework.shared.TestRegistering
 
 /**
  * Executes a test for each provided data parameter.
@@ -142,6 +141,113 @@ fun <Data> TestSuite.withData(
     }
 }
 
+data class ConfiguredDataTestScope<Data>(
+    val testSuite: TestSuite, val nameFn: (Data) -> String, val data: Iterable<Data>,
+    val testConfig: TestConfig = TestConfig,
+) {
+    operator fun minus(action: TestSuite.(Data) -> Unit) = testSuite.withDataSuites(nameFn, data, testConfig, action)
+}
+
+data class ConfiguredMapDataTestScope<Data>(
+    val testSuite: TestSuite, val map: Map<String, Data>,
+    val testConfig: TestConfig = TestConfig,
+) {
+    operator fun minus(action: TestSuite.(Data) -> Unit) = testSuite.withDataSuites(map, testConfig, action)
+}
+
+/**
+ * Creates a configured test suite scope to generate test suites for each provided data parameter.
+ *
+ * @param parameters The data parameters to create suites for
+ * @param testConfig Optional test configuration
+ */
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+@kotlin.internal.LowPriorityInOverloadResolution
+fun <Data> TestSuite.withData(
+    vararg parameters: Data,
+    testConfig: TestConfig = TestConfig
+) = ConfiguredDataTestScope<Data>(this, { "$it" }, parameters.asIterable(), testConfig)
+
+/**
+ * Creates a configured test suite scope to generate test suites for each item in the provided iterable data.
+ *
+ * @param data The iterable collection of test data
+ * @param testConfig Optional test configuration
+ */
+fun <Data> TestSuite.withData(
+    data: Iterable<Data>,
+    testConfig: TestConfig = TestConfig,
+) = ConfiguredDataTestScope<Data>(this, { "$it" }, data, testConfig)
+
+/**
+ * Creates a configured test suite scope to generate test suites for each entry in the provided map.
+ * Uses map keys as suite names.
+ *
+ * @param map Map of suite names to test data
+ * @param testConfig Optional test configuration
+ */
+fun <Data> TestSuite.withData(
+    map: Map<String, Data>,
+    testConfig: TestConfig = TestConfig,
+) = ConfiguredMapDataTestScope<Data>(this, map, testConfig)
+
+/**
+ * Creates a configured test suite scope to generate test suites for each item in the provided sequence.
+ *
+ * @param data The sequence of test data
+ * @param testConfig Optional test configuration
+ */
+fun <Data> TestSuite.withData(
+    data: Sequence<Data>,
+    testConfig: TestConfig = TestConfig
+) = ConfiguredDataTestScope<Data>(this, { "$it" }, data.asIterable(), testConfig)
+
+
+/**
+ * Creates a configured test suite scope to generate test suites for each provided data parameter.
+ * Uses provided function to generate suite names.
+ *
+ * @param nameFn Function to generate suite name from data
+ * @param arguments The data parameters to create suites for
+ * @param testConfig Optional test configuration
+ */
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+@kotlin.internal.LowPriorityInOverloadResolution
+fun <Data> TestSuite.withDataSuites(
+    nameFn: (Data) -> String,
+    vararg arguments: Data,
+    testConfig: TestConfig = TestConfig
+): ConfiguredDataTestScope<Data> = withData(nameFn = nameFn, data = arguments.asIterable(), testConfig = testConfig)
+
+
+/**
+ * Creates a configured test suite scope to generate test suites for each item in the provided iterable data.
+ * Uses provided function to generate suite names.
+ *
+ * @param nameFn Function to generate suite name from data
+ * @param data The iterable collection of test data
+ * @param testConfig Optional test configuration
+ */
+fun <Data> TestSuite.withData(
+    nameFn: (Data) -> String,
+    data: Iterable<Data>,
+    testConfig: TestConfig = TestConfig,
+) = ConfiguredDataTestScope<Data>(this, nameFn, data, testConfig)
+
+
+/**
+ * Creates a configured test suite scope to generate test suites  for each item in the provided sequence.
+ * Uses provided function to generate suite names.
+ *
+ * @param nameFn Function to generate suite name from data
+ * @param data The sequence of test data
+ * @param testConfig Optional test configuration
+ */
+fun <Data> TestSuite.withData(
+    nameFn: (Data) -> String,
+    data: Sequence<Data>,
+    testConfig: TestConfig = TestConfig,
+) = ConfiguredDataTestScope<Data>(this, nameFn, data.asIterable(), testConfig)
 
 /**
  * Creates a test suite for each provided data parameter.

--- a/datatest/src/commonTest/kotlin/DataTest.kt
+++ b/datatest/src/commonTest/kotlin/DataTest.kt
@@ -10,4 +10,13 @@ val aDataDrivenSuite by testSuite {
             word shouldBe "three"
         }
     }
+
+    //Alternative syntax for withDataSuites
+    // -> NOTE the minus ↙↙↙
+    withData(1, 2, 3, 4) - { number ->
+        withData("one", "two", "three", "four") { word ->
+            number shouldBe number
+            word shouldBe "three"
+        }
+    }
 }

--- a/fixturegen-freespec/src/commonMain/kotlin/at/asitplus/test/TestBalloonFixtureGenFreesepc.kt
+++ b/fixturegen-freespec/src/commonMain/kotlin/at/asitplus/test/TestBalloonFixtureGenFreesepc.kt
@@ -4,7 +4,6 @@ import de.infix.testBalloon.framework.core.TestConfig
 import de.infix.testBalloon.framework.core.TestExecutionScope
 import de.infix.testBalloon.framework.core.TestSuite
 import de.infix.testBalloon.framework.core.disable
-import de.infix.testBalloon.framework.shared.TestRegistering
 
 
 context(fixture: MutatingFixtureScope<T>)
@@ -12,14 +11,16 @@ context(fixture: MutatingFixtureScope<T>)
  * Creates a test case with the specified name and configuration.
  *
  * @param testConfig Optional test configuration
+ * @property displayName optional display name override
  * @param nested The test body to execute.
  */
 inline operator fun <reified T> String.invoke(
+    displayName: String = this,
     testConfig: TestConfig = TestConfig,
     crossinline nested: suspend TestExecutionScope.(T) -> Unit
 ) {
     fixture.testSuite.apply {
-        this@invoke.freespec(fixture.testSuite, testConfig) {
+        this@invoke.freespec(displayName, fixture.testSuite, testConfig) {
             nested(fixture.generator())
         }
     }
@@ -28,13 +29,13 @@ inline operator fun <reified T> String.invoke(
 
 //need to replicate freespec leaf functionality here to disambiguate
 @PublishedApi
-@TestRegistering
 internal fun String.freespec(
+    displayName: String = this,
     suite: TestSuite,
     testConfig: TestConfig = TestConfig,
     nested: suspend TestExecutionScope.() -> Unit
 ) {
-    suite.test(testName2(this), testConfig = testConfig.disableByName2(this)) { nested() }
+    suite.test(testName2(this), displayName = displayName, testConfig = testConfig.disableByName2(this)) { nested() }
 }
 
 private fun TestConfig.disableByName2(name: String) =

--- a/freespec/src/commonMain/kotlin/at/asitplus/test/TestBalloonFreeSpec.kt
+++ b/freespec/src/commonMain/kotlin/at/asitplus/test/TestBalloonFreeSpec.kt
@@ -11,32 +11,62 @@ context(suite: TestSuite)
  * Creates a test case with the specified name and configuration.
  *
  * @param testConfig Optional test configuration
+ * @property displayName optional display name override
  * @param nested The test body to execute.
  */
 @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
 @kotlin.internal.LowPriorityInOverloadResolution
-operator fun String.invoke(testConfig: TestConfig = TestConfig, nested: suspend TestExecutionScope.() -> Unit) {
-    suite.test(testName(this), testConfig = testConfig.disableByName(this)) { nested() }
+operator fun String.invoke(
+    displayName: String = this,
+    testConfig: TestConfig = TestConfig,
+    nested: suspend TestExecutionScope.() -> Unit
+) {
+    suite.test(testName(this), displayName = displayName, testConfig = testConfig.disableByName(this)) { nested() }
 }
 
 
 /**
  * Represents a configured test suite with its parent suite, name, and configuration.
  *
- * @property parent The parent test suite.
- * @property name The name of the suite.
- * @property config The configuration for the suite.
+ * @property parent The parent test suite
+ * @property testName The name of the suite
+ * @property displayName optional display name override
+ * @property config The configuration for the suite
  */
-data class ConfiguredSuite(val parent: TestSuite, val name: String, val config: TestConfig)
+data class ConfiguredSuite(
+    val parent: TestSuite,
+    val displayName: String,
+    val testName: String,
+    val config: TestConfig
+) {
+    /**
+     * Creates a test suite from a configured suite with the specified body.
+     *
+     * @param suiteBody The body of the test suite.
+     */
+    infix operator fun minus(suiteBody: TestSuite.() -> Unit) {
+        parent.testSuite(
+            testName(testName),
+            displayName = displayName,
+            testConfig = config.disableByName(displayName),
+            content = fun TestSuite.() {
+                suiteBody()
+            })
+    }
+
+}
 
 context(suite: TestSuite)
+
 /**
  * Creates a configured suite with the specified name and configuration.
  *
  * @param testConfig Optional test configuration
+ * @param displayName Optional display name override
  * @return A new [ConfiguredSuite] instance.
  */
-operator fun String.invoke(testConfig: TestConfig = TestConfig) = ConfiguredSuite(suite, this, testConfig)
+operator fun String.invoke(displayName: String = this, testConfig: TestConfig = TestConfig) =
+    ConfiguredSuite(suite, displayName, this, testConfig)
 
 context(suite: TestSuite)
 /**
@@ -46,17 +76,6 @@ context(suite: TestSuite)
  */
 infix operator fun String.minus(suiteBody: TestSuite.() -> Unit) {
     suite.testSuite(name = testName(this), testConfig = TestConfig.disableByName(this), content = fun TestSuite.() {
-        suiteBody()
-    })
-}
-
-/**
- * Creates a test suite from a configured suite with the specified body.
- *
- * @param suiteBody The body of the test suite.
- */
-infix operator fun ConfiguredSuite.minus(suiteBody: TestSuite.() -> Unit) {
-    parent.testSuite(testName(name), testConfig = config.disableByName(name), content = fun TestSuite.() {
         suiteBody()
     })
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -Xms200m
 kotlin.daemon.jvm.options=-Xmx10G -Xms200m
 kotlin.daemon.jvmargs=-Xmx10g -Xms200m
-artifactVersion = 0.1.1
+artifactVersion = 0.1.2
 jdk.version=17
 android.minSdk=21
 android.compileSdk=34

--- a/property/src/commonTest/kotlin/PropertyTest.kt
+++ b/property/src/commonTest/kotlin/PropertyTest.kt
@@ -15,4 +15,13 @@ val propertySuite by testSuite {
             number shouldBe byteArray.size
         }
     }
+
+    //Alternative syntax for checkAllSuites
+    // --> NOTE THE MINUS HERE >->-->--------------------------------------↘↘↘
+    checkAll(iterations = 100, Arb.byteArray(Arb.int(100, 200), Arb.byte())) - { byteArray ->
+        checkAll(iterations = 10, Arb.uLong()) { number ->
+            byteArray shouldBe byteArray
+            number shouldBe byteArray.size
+        }
+    }
 }


### PR DESCRIPTION
## New, alternative syntaxes

```kotlin
//Alternative syntax for withDataSuites
// -> NOTE the minus ↙↙↙
withData(1, 2, 3, 4) - { number ->
    withData("one", "two", "three", "four") { word ->
        //your test logic being run 16 times
    }
}
```

```kotlin
//Alternative syntax for checkAllSuites
// --> NOTE THE MINUS HERE >->-->--------------------------------------↘↘↘
checkAll(iterations = 100, Arb.byteArray(Arb.int(100, 200), Arb.byte())) - { byteArray ->
    checkAll(iterations = 10, Arb.uLong()) { number ->
        //test with byte arrays and number for fun and profit
    }
}
```



@OliverO2 can you please sparkle it with `@TestDiscoverable`? I can't seem to find the right spots to make gutter icons show up. Everything runs, though…