### PR TITLE
Feature/bare generators

### DIFF
--- a/.github/workflows/demo-report.yml
+++ b/.github/workflows/demo-report.yml
@@ -1,0 +1,54 @@
+name: Demonstrate Reporting
+on:
+  # still run checks on every PR *before* the merge
+  pull_request:
+
+  # run the workflow once more **after** the PR has been merged
+  push:
+    branches:
+      - main
+      - development
+
+jobs:
+  build:
+    runs-on: macos-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout (default)
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      # For pull_request_target, explicitly fetch the PR head
+      - name: Checkout PR head (for pull_request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          submodules: recursive
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2.0
+      - name: Run tests
+        run: ./gradlew allTests || true
+      - name: Test Report
+        uses: dorny/test-reporter@v2
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        if: success() || failure()
+        with:
+          name: Tests
+          path: '**/build/test-results/**/TEST*.xml'
+          reporter: java-junit
+          list-suites: failed
+          list-tests: failed
+          use-actions-summary: true
+          fail-on-error: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,11 @@
 name: Publish
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      modules:
+        description: 'Comma-separated list of module names to publish'
+        required: false
+        default: 'internals,commons,matrix,freespec,property,datatest,fixturegen,fixturegen-freespec'
 permissions:
   contents: read
   pages: write
@@ -23,15 +29,18 @@ jobs:
       - name: Publish modules serially to Sonatype
         run: |
           ./gradlew clean
-          ./gradlew :internals:publishToSonatype closeSonatypeStagingRepository
-          ./gradlew :commons:publishToSonatype closeSonatypeStagingRepository
-          ./gradlew :matrix:publishToSonatype closeSonatypeStagingRepository
-          ./gradlew :freespec:publishToSonatype closeSonatypeStagingRepository
-          ./gradlew :property:publishToSonatype closeSonatypeStagingRepository
-          ./gradlew :datatest:publishToSonatype closeSonatypeStagingRepository
-          ./gradlew :fixturegen:publishToSonatype closeSonatypeStagingRepository
-          ./gradlew :fixturegen-freespec:publishToSonatype closeSonatypeStagingRepository
+          IFS=',' read -ra MODULES <<< "$PUBLISH_MODULES"
+          for module in "${MODULES[@]}"; do
+            module="$(echo "$module" | xargs)"
+            [ -z "$module" ] && continue
+            case "$module" in
+              *[!a-zA-Z0-9_-]*)
+                echo "::error::Invalid module name: '$module'"; exit 1 ;;
+            esac
+            ./gradlew ":${module}:publishToSonatype" closeSonatypeStagingRepository
+          done
         env:
+          PUBLISH_MODULES: ${{ github.event.inputs.modules }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PUBLISH_SIGNING_KEYID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PUBLISH_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PUBLISH_SIGNING_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
       nameless layers alike (e.g. `(property) seed: ...`). Nameless layers print the marker without a name; the
       general failure/report path still shows no synthesized segment.
 * **Matrix testing: replace layer separator slash with TestBalloon separator arrow**
+* **Matrix testing: replay info shows the full path**
+    * The `Error replay info` path now mirrors the compact report path in full — enclosing grouping suites
+      (`"name" - { ... }`) and plain `test` leaves appear as path segments, not just the replayable `data`/`property`
+      layers. Only replayable layers still emit a `- ...` argument line; group-only chains produce no replay block.
 
 ## 0.11.0
 * **Matrix testing: bounded compact concurrency**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.12.0
+* **Matrix testing: nameless `data` / `property` layers**
+    * `data` and `property` now have overloads that omit the leading name (e.g. `data(listOf(...)) test { ... }`,
+      `property(Arb.int()) - { ... }`). A nameless layer skips the intermediate grouping node and registers its rows
+      directly in the surrounding scope. A named layer remains shorthand for wrapping a nameless one in a labeled
+      suite. Available in both regular and `compact` scopes, across all overloads (Iterable/Sequence,
+      `replayIndex(es)` / `replay(s)`, `- { }` and `test { }`).
+* **Matrix testing: replay info shows layer kind**
+    * `Error replay info` frames are now tagged with their layer kind — `(property)` or `(data)` — for named and
+      nameless layers alike (e.g. `(property) seed: ...`). Nameless layers print the marker without a name; the
+      general failure/report path still shows no synthesized segment.
+
 ## 0.11.0
 * **Matrix testing: bounded compact concurrency**
     * `CompactConcurrency.Shared(n)` runs a compact block through one compact-wide worker budget, so nested virtual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     * `Error replay info` frames are now tagged with their layer kind — `(property)` or `(data)` — for named and
       nameless layers alike (e.g. `(property) seed: ...`). Nameless layers print the marker without a name; the
       general failure/report path still shows no synthesized segment.
+* **Matrix testing: replace layer separator slash with TestBalloon separator arrow**
 
 ## 0.11.0
 * **Matrix testing: bounded compact concurrency**

--- a/README.md
+++ b/README.md
@@ -243,8 +243,11 @@ Each pinned layer collapses to just the recorded case, so the whole matrix narro
 * A layer's `replay` / `replayIndex` is independent of its `seed`: `seed` pins a deterministic *full* run, while
   `replay` selects specific recorded cases (which carry their own seeds).
 
-Replay info inherits the enclosing layers' frames, so a compacted leaf records the full chain (outer real layers
-included), and the data index is recorded even when a custom `nameFn` omits it from the displayed name.
+The path on the first line mirrors the compact report path in full: it includes the enclosing grouping suites
+(`"name" - { ... }`) as plain segments, with the `(property)` / `(data)` layers carrying the markers. Only the
+replayable layers get a `- ...` argument line below — grouping suites appear in the path but have nothing to paste.
+A compacted leaf therefore records the full chain (outer real layers included), and the data index is recorded even
+when a custom `nameFn` omits it from the displayed name.
 
 ### Fixtures
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ val quickstart by matrixSuite(execution = ExecutionMode.Sequential) {
 }
 ```
 
+A layer's leading name is just a label for a grouping node that wraps the rows it generates. Naming a layer is
+shorthand for wrapping a nameless one in a labeled suite by hand — these two produce the same test-tree shape:
+
+```kotlin
+data("numbers", listOf(1, 2, 3)) - { /* … */ }   // named layer
+
+"numbers" - {                                    // equivalent structure
+    data(listOf(1, 2, 3)) - { /* … */ }
+}
+```
+
+Both nest the three rows under a `numbers` node. Drop the name entirely (`data(listOf(1, 2, 3))`) and the rows attach
+directly to the surrounding scope with no grouping node at all. The name, when present, additionally becomes the
+layer's label in failure/replay output (`(data) numbers: …`); a nameless layer just shows its kind (`(data) …`). The
+same applies to `property`. The sections below use named layers throughout, but every `data`/`property` form has a
+nameless overload.
+
 ### Data-Driven Matrix Layers
 
 `data` layers accept `Iterable` values and lazy `Sequence` values. Use `test { ... }` when each row is the test, and
@@ -114,7 +131,7 @@ val dataDrivenMatrix by matrixSuite(execution = ExecutionMode.Sequential) {
         number shouldBeGreaterThan 0
     }
 
-    data("as a dimension", listOf("foo", "bar")) - { word ->
+    data("string data", listOf("foo", "bar")) - { word ->
         "has a length" {
             word.length shouldBeGreaterThan 0
         }
@@ -189,15 +206,16 @@ all generated checks: compact progress: 512 of 900 queued completed (1200 source
 
 Every matrix failure — a real test-tree leaf or a compacted virtual row — carries an **`Error replay info`**
 block whose detail lines are valid `property` / `data` arguments. Copy them back onto the failing layers and the
-matrix re-runs exactly those cases.
+matrix re-runs exactly those cases. Each frame is tagged with its layer kind — `(property)` or `(data)` — so the
+marker still pinpoints the right layer even for nameless layers (see below), where no layer name is printed.
 
 ```
 at.asitplus.AssertionError: 360888 should be < 256000
-    Error replay info: first: 4: 2018089192 / second: 2: 2796 / third: 1: 2 / fourth: 3: 1
-      - first:  replay = ReplayInput(seed=4779463605442148766L, iteration=4L)
-      - second: replay = ReplayInput(seed=-1353176301820643450L, iteration=2L)
-      - third:  replayIndex = 1L
-      - fourth: replay = ReplayInput(seed=5014696554795393980L, iteration=3L)
+    Error replay info: (property) first: 4: 2018089192 / (property) second: 2: 2796 / (data) third: 1: 2 / (property) fourth: 3: 1
+      - (property) first:  replay = ReplayInput(seed=4779463605442148766L, iteration=4L)
+      - (property) second: replay = ReplayInput(seed=-1353176301820643450L, iteration=2L)
+      - (data)     third:  replayIndex = 1L
+      - (property) fourth: replay = ReplayInput(seed=5014696554795393980L, iteration=3L)
 ```
 
 Paste the text after each layer name into that layer's call:
@@ -230,25 +248,61 @@ included), and the data index is recorded even when a custom `nameFn` omits it f
 
 ### Fixtures
 
-`fixture` creates fresh values for each directly nested test or suite. It also works inside compact blocks.
+`fixture { ... }` produces a fresh value, and **every test or suite you declare inside its `- { ... }` block gains an
+extra lambda parameter that hands you that value**. You name that parameter yourself — it is the freshly generated
+fixture, scoped to the element it is attached to:
+
+```kotlin
+fixture { Random.nextBytes(16) } - {
+    //                              ^ open the fixture scope with `- { }`
+
+    "a single test" { bytes ->   // <-- `bytes` is the fixture, freshly generated for THIS test
+        bytes.size shouldBe 16
+    }
+
+    "a nested suite" - { bytes ->   // <-- `bytes` is one fixture, shared by everything in this suite
+        data("word", listOf("foo", "bar")) test { word ->
+            bytes.isNotEmpty() shouldBe true
+        }
+    }
+}
+```
+
+The parameter appears on **every** nested form — `"name" { value -> }`, `"name" - { value -> }`,
+`test(...) { value -> }`, and `testSuite(...) { value -> }` — so the fixture threads in wherever you declare a child.
+
+Freshness follows the element the lambda is attached to:
+
+* a **terminal test** (`"name" { value -> }` / `test { value -> }`) gets its **own** fresh value;
+* a **suite** (`"name" - { value -> }`) gets **one** fresh value that all of its children share.
+
+So fixtures isolate per test by default, but give you a single shared instance when you group children under a suite.
+
+Directly inside the fixture block you can only declare tests and suites — not `data`/`property`/`compact` layers. To add
+those, open a suite first: a `"name" - { value -> ... }` body is a normal matrix scope, so every layer you declare in it
+closes over that suite's `value`. Nesting composes the other direction too: a `fixture` inside a `data` row regenerates
+once per row, and a `fixture` inside another fixture's suite threads both values down to the leaves.
 
 ```kotlin
 val fixtureMatrix by matrixSuite(execution = ExecutionMode.Concurrent()) {
     fixture { Random.nextBytes(16) } - {
-        "regular test with fresh bytes" { bytes ->
+        "regular test with fresh bytes" { bytes ->        // fresh value, this test only
             bytes.size shouldBe 16
         }
 
-        "suite with a fresh fixture" - { bytes ->
-            data("word", listOf("foo", "bar")) test { word ->
+        "suite with a shared fixture" - { bytes ->        // one value for the whole suite; `- { }` opens a matrix scope,
+            data("word", listOf("foo", "bar")) test { word ->   // so data/property/compact layers are available here
                 bytes.isNotEmpty() shouldBe true
                 word.length shouldBeGreaterThan 0
             }
         }
+    }
 
-        compact("compact checks with fresh fixture") { report = CompactReport.AllCases } - {
-            data("byte", bytes.toList()) test { byte ->
-                byte shouldBe byte
+    // Fixtures also work inside compact blocks — same parameter, same freshness rules:
+    compact("compact checks with fresh fixture") { report = CompactReport.AllCases } - {
+        fixture { Random.nextBytes(16) } - {
+            "fresh bytes per row" { bytes ->
+                bytes.size shouldBe 16
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ marker still pinpoints the right layer even for nameless layers (see below), whe
 
 ```
 at.asitplus.AssertionError: 360888 should be < 256000
-    Error replay info: (property) first: 4: 2018089192 / (property) second: 2: 2796 / (data) third: 1: 2 / (property) fourth: 3: 1
+    Error replay info: (property) first: 4: 2018089192 ↘ (property) second: 2: 2796 ↘ (data) third: 1: 2 ↘ (property) fourth: 3: 1
       - (property) first:  replay = ReplayInput(seed=4779463605442148766L, iteration=4L)
       - (property) second: replay = ReplayInput(seed=-1353176301820643450L, iteration=2L)
       - (data)     third:  replayIndex = 1L

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -Xms200m
 kotlin.daemon.jvm.options=-Xmx10G -Xms200m
 kotlin.daemon.jvmargs=-Xmx10g -Xms200m
-artifactVersion = 0.11.0
+artifactVersion = 0.12.0
 jdk.version=17
 android.minSdk=21
 android.compileSdk=34

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/Matrix.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/Matrix.kt
@@ -70,7 +70,13 @@ data class MatrixSuiteScope internal constructor(
                 name = matrixName(name),
                 testConfig = config.testConfig.chainedWith(testConfig).disableByMatrixName(name),
             ) {
-                MatrixSuiteScope(this, config, registrationPath, registrationReporter, replayPath).body()
+                MatrixSuiteScope(
+                    this,
+                    config,
+                    registrationPath,
+                    registrationReporter,
+                    replayPath + MatrixReplayFrame.Group(matrixName(name)),
+                ).body()
             }
         }
     }
@@ -85,7 +91,7 @@ data class MatrixSuiteScope internal constructor(
             test(
                 name = matrixName(name),
                 testConfig = config.testConfig.chainedWith(testConfig).disableByMatrixName(name),
-                action = { withMatrixReplay(replayPath, body) },
+                action = { withMatrixReplay(replayPath + MatrixReplayFrame.Group(matrixName(name)), body) },
             )
         }
     }

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/Matrix.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/Matrix.kt
@@ -147,8 +147,38 @@ data class MatrixSuiteScope internal constructor(
         config: DataLayerConfigBuilder.() -> Unit = {},
     ): MatrixDataLayer<T> = data(name, values, limit, nameFn, listOf(replayIndex), config)
 
+    fun <T> data(
+        values: Iterable<T>,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replayIndexes: List<Long>? = null,
+        config: DataLayerConfigBuilder.() -> Unit = {},
+    ): MatrixDataLayer<T> = MatrixDataLayer(this, null, IterableDataSource(values), nameFn, replayIndexes, config)
+
+    fun <T> data(
+        values: Iterable<T>,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replayIndex: Long,
+        config: DataLayerConfigBuilder.() -> Unit = {},
+    ): MatrixDataLayer<T> = data(values, nameFn, listOf(replayIndex), config)
+
+    fun <T> data(
+        values: Sequence<T>,
+        limit: Long? = null,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replayIndexes: List<Long>? = null,
+        config: DataLayerConfigBuilder.() -> Unit = {},
+    ): MatrixDataLayer<T> = MatrixDataLayer(this, null, SequenceDataSource(values, limit), nameFn, replayIndexes, config)
+
+    fun <T> data(
+        values: Sequence<T>,
+        limit: Long? = null,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replayIndex: Long,
+        config: DataLayerConfigBuilder.() -> Unit = {},
+    ): MatrixDataLayer<T> = data(values, limit, nameFn, listOf(replayIndex), config)
+
     internal fun <T> dataInternal(
-        name: String,
+        name: String?,
         source: MatrixDataSource<T>,
         nameFn: NameFn<T>,
         replayIndexes: List<Long>?,
@@ -156,41 +186,44 @@ data class MatrixSuiteScope internal constructor(
         body: MatrixSuiteScope.(T) -> Unit,
     ) {
         val layerConfig = DataLayerConfigBuilder(config).apply(configBlock).build(replayIndexes)
-        val strippedName = matrixName(name)
+        val layerName = name?.let(::matrixName)
+        val registrationName = layerName ?: "data"
         val iterator = source.cases(layerConfig.replayIndexes)
         val dataConfig = config.copy(execution = layerConfig.execution)
         val caseLimiter = layerConfig.execution.caseLimiter()
         val caseTestConfig = dataConfig.testConfig.boundBy(caseLimiter)
-        target.apply {
-            testSuite(name = strippedName, testConfig = dataConfig.testConfig.disableByMatrixName(name)) {
-                val progress = registrationProgress(strippedName, source.knownSize, registrationPath, registrationReporter)
-                var registered = 0L
-                progress.registered(registered)
-                while (iterator.hasNext()) {
-                    val case = iterator.next()
-                    val caseName = nameFn(case.index, case.value).truncated(layerConfig.nameMaxLength)
-                    val replayFrame = MatrixReplayFrame.Data(strippedName, case.index, caseName)
-                    testSuite(
-                        name = caseName,
-                        testConfig = caseTestConfig
-                    ) {
-                        MatrixSuiteScope(
-                            this,
-                            dataConfig,
-                            registrationPath + MatrixRegistrationFrame(strippedName, case.index, source.knownSize),
-                            registrationReporter,
-                            replayPath + replayFrame,
-                        ).body(case.value)
-                    }
-                    progress.registered(++registered)
+        val register: TestSuiteScope.() -> Unit = {
+            val progress = registrationProgress(registrationName, source.knownSize, registrationPath, registrationReporter)
+            var registered = 0L
+            progress.registered(registered)
+            while (iterator.hasNext()) {
+                val case = iterator.next()
+                val caseName = nameFn(case.index, case.value).truncated(layerConfig.nameMaxLength)
+                val replayFrame = MatrixReplayFrame.Data(layerName, case.index, caseName)
+                testSuite(
+                    name = caseName,
+                    testConfig = caseTestConfig
+                ) {
+                    MatrixSuiteScope(
+                        this,
+                        dataConfig,
+                        registrationPath + MatrixRegistrationFrame(registrationName, case.index, source.knownSize),
+                        registrationReporter,
+                        replayPath + replayFrame,
+                    ).body(case.value)
                 }
-                progress.completed(registered)
+                progress.registered(++registered)
             }
+            progress.completed(registered)
+        }
+        target.apply {
+            if (name == null) register()
+            else testSuite(name = registrationName, testConfig = dataConfig.testConfig.disableByMatrixName(name)) { register() }
         }
     }
 
     internal fun <T> dataTestInternal(
-        name: String,
+        name: String?,
         source: MatrixDataSource<T>,
         nameFn: NameFn<T>,
         replayIndexes: List<Long>?,
@@ -198,30 +231,33 @@ data class MatrixSuiteScope internal constructor(
         body: suspend Test.ExecutionScope.(T) -> Unit,
     ) {
         val layerConfig = DataLayerConfigBuilder(config).apply(configBlock).build(replayIndexes)
-        val strippedName = matrixName(name)
+        val layerName = name?.let(::matrixName)
+        val registrationName = layerName ?: "data"
         val iterator = source.cases(layerConfig.replayIndexes)
         val dataConfig = config.copy(execution = layerConfig.execution)
         val caseLimiter = layerConfig.execution.caseLimiter()
         val caseTestConfig = dataConfig.testConfig.boundBy(caseLimiter)
-        target.apply {
-            testSuite(name = strippedName, testConfig = dataConfig.testConfig.disableByMatrixName(name)) {
-                val progress = registrationProgress(strippedName, source.knownSize, registrationPath, registrationReporter)
-                var registered = 0L
-                progress.registered(registered)
-                while (iterator.hasNext()) {
-                    val case = iterator.next()
-                    val caseName = nameFn(case.index, case.value).truncated(layerConfig.nameMaxLength)
-                    val replayFrame = MatrixReplayFrame.Data(strippedName, case.index, caseName)
-                    test(
-                        name = caseName,
-                        testConfig = caseTestConfig,
-                    ) {
-                        withMatrixReplay(replayPath + replayFrame) { body(case.value) }
-                    }
-                    progress.registered(++registered)
+        val register: TestSuiteScope.() -> Unit = {
+            val progress = registrationProgress(registrationName, source.knownSize, registrationPath, registrationReporter)
+            var registered = 0L
+            progress.registered(registered)
+            while (iterator.hasNext()) {
+                val case = iterator.next()
+                val caseName = nameFn(case.index, case.value).truncated(layerConfig.nameMaxLength)
+                val replayFrame = MatrixReplayFrame.Data(layerName, case.index, caseName)
+                test(
+                    name = caseName,
+                    testConfig = caseTestConfig,
+                ) {
+                    withMatrixReplay(replayPath + replayFrame) { body(case.value) }
                 }
-                progress.completed(registered)
+                progress.registered(++registered)
             }
+            progress.completed(registered)
+        }
+        target.apply {
+            if (name == null) register()
+            else testSuite(name = registrationName, testConfig = dataConfig.testConfig.disableByMatrixName(name)) { register() }
         }
     }
 
@@ -243,8 +279,24 @@ data class MatrixSuiteScope internal constructor(
         config: PropertyLayerConfigBuilder.() -> Unit = {},
     ): MatrixPropertyLayer<T> = property(name, gen, iterations, nameFn, listOf(replay), config)
 
+    fun <T> property(
+        gen: Gen<T>,
+        iterations: Int = this@MatrixSuiteScope.config.defaultPropertyIterations,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replays: List<ReplayInput>? = null,
+        config: PropertyLayerConfigBuilder.() -> Unit = {},
+    ): MatrixPropertyLayer<T> = MatrixPropertyLayer(this, null, gen, iterations, nameFn, replays, config)
+
+    fun <T> property(
+        gen: Gen<T>,
+        iterations: Int = this@MatrixSuiteScope.config.defaultPropertyIterations,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replay: ReplayInput,
+        config: PropertyLayerConfigBuilder.() -> Unit = {},
+    ): MatrixPropertyLayer<T> = property(gen, iterations, nameFn, listOf(replay), config)
+
     internal fun <T> propertyInternal(
-        name: String,
+        name: String?,
         gen: Gen<T>,
         iterations: Int,
         nameFn: NameFn<T>,
@@ -253,42 +305,45 @@ data class MatrixSuiteScope internal constructor(
         body: MatrixSuiteScope.(T) -> Unit,
     ) {
         require(iterations >= 0) { "iterations must be >= 0" }
-        val strippedName = matrixName(name)
+        val layerName = name?.let(::matrixName)
+        val registrationName = layerName ?: "property"
         val layerConfig = PropertyLayerConfigBuilder(this.config).apply(config).build(replays)
         val propertyConfig = this@MatrixSuiteScope.config.copy(execution = layerConfig.execution)
         val caseLimiter = layerConfig.execution.caseLimiter()
         val caseTestConfig = propertyConfig.testConfig.boundBy(caseLimiter)
-        target.apply {
-            testSuite(strippedName, testConfig = propertyConfig.testConfig.disableByMatrixName(name)) {
-                val progress = registrationProgress(strippedName, layerConfig.caseCount(iterations), registrationPath, registrationReporter)
-                val iterator = propertyCases(gen, iterations, layerConfig.edgeConfig, layerConfig.seed, layerConfig.replays)
-                var registered = 0L
-                progress.registered(registered)
-                while (iterator.hasNext()) {
-                    val case = iterator.next()
-                    val caseName = nameFn(case.index, case.value).truncated(layerConfig.nameMaxLength)
-                    val replayFrame = MatrixReplayFrame.Property(strippedName, case.seed!!, case.index, caseName)
-                    testSuite(
-                        name = caseName,
-                        testConfig = caseTestConfig
-                    ) {
-                        MatrixSuiteScope(
-                            this,
-                            propertyConfig,
-                            registrationPath + MatrixRegistrationFrame(strippedName, case.index, iterations.toLong()),
-                            registrationReporter,
-                            replayPath + replayFrame,
-                        ).body(case.value)
-                    }
-                    progress.registered(++registered)
+        val register: TestSuiteScope.() -> Unit = {
+            val progress = registrationProgress(registrationName, layerConfig.caseCount(iterations), registrationPath, registrationReporter)
+            val iterator = propertyCases(gen, iterations, layerConfig.edgeConfig, layerConfig.seed, layerConfig.replays)
+            var registered = 0L
+            progress.registered(registered)
+            while (iterator.hasNext()) {
+                val case = iterator.next()
+                val caseName = nameFn(case.index, case.value).truncated(layerConfig.nameMaxLength)
+                val replayFrame = MatrixReplayFrame.Property(layerName, case.seed!!, case.index, caseName)
+                testSuite(
+                    name = caseName,
+                    testConfig = caseTestConfig
+                ) {
+                    MatrixSuiteScope(
+                        this,
+                        propertyConfig,
+                        registrationPath + MatrixRegistrationFrame(registrationName, case.index, iterations.toLong()),
+                        registrationReporter,
+                        replayPath + replayFrame,
+                    ).body(case.value)
                 }
-                progress.completed(registered)
+                progress.registered(++registered)
             }
+            progress.completed(registered)
+        }
+        target.apply {
+            if (name == null) register()
+            else testSuite(registrationName, testConfig = propertyConfig.testConfig.disableByMatrixName(name)) { register() }
         }
     }
 
     internal fun <T> propertyTestInternal(
-        name: String,
+        name: String?,
         gen: Gen<T>,
         iterations: Int,
         nameFn: NameFn<T>,
@@ -297,31 +352,34 @@ data class MatrixSuiteScope internal constructor(
         body: suspend Test.ExecutionScope.(T) -> Unit,
     ) {
         require(iterations >= 0) { "iterations must be >= 0" }
-        val strippedName = matrixName(name)
+        val layerName = name?.let(::matrixName)
+        val registrationName = layerName ?: "property"
         val layerConfig = PropertyLayerConfigBuilder(this.config).apply(config).build(replays)
         val propertyConfig = this@MatrixSuiteScope.config.copy(execution = layerConfig.execution)
         val caseLimiter = layerConfig.execution.caseLimiter()
         val caseTestConfig = propertyConfig.testConfig.boundBy(caseLimiter)
-        target.apply {
-            testSuite(strippedName, testConfig = propertyConfig.testConfig.disableByMatrixName(name)) {
-                val progress = registrationProgress(strippedName, layerConfig.caseCount(iterations), registrationPath, registrationReporter)
-                val iterator = propertyCases(gen, iterations, layerConfig.edgeConfig, layerConfig.seed, layerConfig.replays)
-                var registered = 0L
-                progress.registered(registered)
-                while (iterator.hasNext()) {
-                    val case = iterator.next()
-                    val caseName = nameFn(case.index, case.value).truncated(layerConfig.nameMaxLength)
-                    val replayFrame = MatrixReplayFrame.Property(strippedName, case.seed!!, case.index, caseName)
-                    test(
-                        name = caseName,
-                        testConfig = caseTestConfig,
-                    ) {
-                        withMatrixReplay(replayPath + replayFrame) { body(case.value) }
-                    }
-                    progress.registered(++registered)
+        val register: TestSuiteScope.() -> Unit = {
+            val progress = registrationProgress(registrationName, layerConfig.caseCount(iterations), registrationPath, registrationReporter)
+            val iterator = propertyCases(gen, iterations, layerConfig.edgeConfig, layerConfig.seed, layerConfig.replays)
+            var registered = 0L
+            progress.registered(registered)
+            while (iterator.hasNext()) {
+                val case = iterator.next()
+                val caseName = nameFn(case.index, case.value).truncated(layerConfig.nameMaxLength)
+                val replayFrame = MatrixReplayFrame.Property(layerName, case.seed!!, case.index, caseName)
+                test(
+                    name = caseName,
+                    testConfig = caseTestConfig,
+                ) {
+                    withMatrixReplay(replayPath + replayFrame) { body(case.value) }
                 }
-                progress.completed(registered)
+                progress.registered(++registered)
             }
+            progress.completed(registered)
+        }
+        target.apply {
+            if (name == null) register()
+            else testSuite(registrationName, testConfig = propertyConfig.testConfig.disableByMatrixName(name)) { register() }
         }
     }
 
@@ -366,7 +424,7 @@ class MatrixConfiguredSuite internal constructor(
 
 class MatrixDataLayer<T> internal constructor(
     private val scope: MatrixSuiteScope,
-    private val name: String,
+    private val name: String?,
     private val source: MatrixDataSource<T>,
     private val nameFn: NameFn<T>,
     private val replayIndexes: List<Long>?,
@@ -383,7 +441,7 @@ class MatrixDataLayer<T> internal constructor(
 
 class MatrixPropertyLayer<T> internal constructor(
     private val scope: MatrixSuiteScope,
-    private val name: String,
+    private val name: String?,
     private val gen: Gen<T>,
     private val iterations: Int,
     private val nameFn: NameFn<T>,

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixCompactExecution.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixCompactExecution.kt
@@ -117,7 +117,7 @@ internal class CompactRun(
                 appendOmittedCounts(reportOmittedFailures, reportOmittedSuccesses)
                 appendLine(" omitted from compact report")
             }
-            if (firstOmittedReplayPath.isNotEmpty()) {
+            if (firstOmittedReplayPath.hasReplayable()) {
                 appendLine(firstOmittedReplayPath.message("First error replay info omitted from row report:"))
             }
             appendLine("----------------------------------------")
@@ -146,13 +146,14 @@ private fun rowLimitCapacity(limit: Int, used: Int = 0): Int =
     if (limit < 0) Int.MAX_VALUE else (limit - used).coerceAtLeast(0)
 
 private fun StringBuilder.appendFailureError(failure: CompactFailure) {
-    val message = if (failure.replayPath.isEmpty()) {
+    val replayable = failure.replayPath.hasReplayable()
+    val message = if (!replayable) {
         failure.error.message
     } else {
         failure.error.cause?.message ?: failure.error.message
     }
     appendLine("  error: ${failure.error::class.simpleName}: $message")
-    if (failure.replayPath.isNotEmpty()) {
+    if (replayable) {
         failure.replayPath.message().lines().forEachIndexed { index, line ->
             append(if (index == 0) "    " else "      ")
             appendLine(line)
@@ -252,11 +253,11 @@ private suspend fun traverseVirtualNodes(
     for (node in nodes) {
         when (node) {
             is VirtualNode.Suite -> if (!node.disabled)
-                traverseVirtualNodes(node.children, run, path + node.name, replayPath, respectLayerConcurrency, onTest)
+                traverseVirtualNodes(node.children, run, path + node.name, replayPath + MatrixReplayFrame.Group(node.name), respectLayerConcurrency, onTest)
             is VirtualNode.DynamicSuite -> if (!node.disabled)
-                traverseVirtualNodes(node.children(), run, path + node.name, replayPath, respectLayerConcurrency, onTest)
+                traverseVirtualNodes(node.children(), run, path + node.name, replayPath + MatrixReplayFrame.Group(node.name), respectLayerConcurrency, onTest)
             is VirtualNode.Test -> if (!node.disabled)
-                onTest(path + node.name, replayPath, node.body)
+                onTest(path + node.name, replayPath + MatrixReplayFrame.Group(node.name), node.body)
 
             is VirtualNode.Data -> if (!node.disabled) traverseLayer(
                 run, node.layerConfig.caseCount(node.source.knownSize), node.source.cases(node.layerConfig.replayIndexes),

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixCompactExecution.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixCompactExecution.kt
@@ -96,7 +96,7 @@ internal class CompactRun(
                 val failureRows = rowLimitCapacity(config.reportRows)
                 failureDetails.take(failureRows).forEach { failure ->
                     append("Failure: ")
-                    append(failure.path.joinToString(" / "))
+                    append(failure.path.joinToString(" ↘ "))
                     appendFailureError(failure)
                     appendLine()
                     renderedRows += 1
@@ -107,7 +107,7 @@ internal class CompactRun(
                 val remainingRows = rowLimitCapacity(config.reportRows, renderedRows)
                 successes.take(remainingRows).forEach { success ->
                     append("OK     : ")
-                    appendLine(success.joinToString(" / "))
+                    appendLine(success.joinToString(" ↘ "))
                     renderedRows += 1
                 }
                 reportOmittedSuccesses += (successes.size - remainingRows).coerceAtLeast(0)
@@ -125,7 +125,7 @@ internal class CompactRun(
             if (first == null) {
                 appendLine("Stack traces omitted: all compact failures were omitted from compact report")
             } else {
-                appendLine("Stack trace of first error: Failure: ${first.path.joinToString(" / ")}")
+                appendLine("Stack trace of first error: Failure: ${first.path.joinToString(" ↘ ")}")
                 appendLine(first.error.stackTraceForCollatedReport())
             }
             appendLine("----------------------------------------")

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixCompactExecution.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixCompactExecution.kt
@@ -305,7 +305,7 @@ private suspend fun traverseLayer(
     run: CompactRun,
     sourceCases: Long?,
     cases: Iterator<Case<Any?>>,
-    layerName: String,
+    layerName: String?,
     nameMaxLength: Int,
     nameOf: NameFn<Any?>,
     frameOf: (case: Case<Any?>, rawName: String) -> MatrixReplayFrame,
@@ -317,7 +317,8 @@ private suspend fun traverseLayer(
     run.addSourceCases(sourceCases)
     cases.forEachCase(execution, run.config.coroutineContext) { case ->
         val rawName = nameOf(case.index, case.value).truncated(nameMaxLength)
-        visit(path + "$layerName: $rawName", replayPath + frameOf(case, rawName), case.value)
+        val pathSegment = if (layerName != null) "$layerName: $rawName" else rawName
+        visit(path + pathSegment, replayPath + frameOf(case, rawName), case.value)
     }
 }
 

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixCompactScope.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixCompactScope.kt
@@ -62,8 +62,38 @@ class CompactScope internal constructor(
         config: DataLayerConfigBuilder.() -> Unit = {},
     ): CompactDataLayer<T> = data(name, values, limit, nameFn, listOf(replayIndex), config)
 
+    fun <T> data(
+        values: Iterable<T>,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replayIndexes: List<Long>? = null,
+        config: DataLayerConfigBuilder.() -> Unit = {},
+    ): CompactDataLayer<T> = CompactDataLayer(this, null, IterableDataSource(values), nameFn, replayIndexes, config)
+
+    fun <T> data(
+        values: Iterable<T>,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replayIndex: Long,
+        config: DataLayerConfigBuilder.() -> Unit = {},
+    ): CompactDataLayer<T> = data(values, nameFn, listOf(replayIndex), config)
+
+    fun <T> data(
+        values: Sequence<T>,
+        limit: Long? = null,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replayIndexes: List<Long>? = null,
+        config: DataLayerConfigBuilder.() -> Unit = {},
+    ): CompactDataLayer<T> = CompactDataLayer(this, null, SequenceDataSource(values, limit), nameFn, replayIndexes, config)
+
+    fun <T> data(
+        values: Sequence<T>,
+        limit: Long? = null,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replayIndex: Long,
+        config: DataLayerConfigBuilder.() -> Unit = {},
+    ): CompactDataLayer<T> = data(values, limit, nameFn, listOf(replayIndex), config)
+
     internal fun <T> dataInternal(
-        name: String,
+        name: String?,
         source: MatrixDataSource<T>,
         nameFn: NameFn<T>,
         replayIndexes: List<Long>?,
@@ -72,8 +102,8 @@ class CompactScope internal constructor(
     ) {
         val layerConfig = DataLayerConfigBuilder(matrixConfig).apply(configBlock).build(replayIndexes)
         nodes += VirtualNode.Data(
-            matrixName(name),
-            disabled = isMatrixDisabledName(name),
+            name?.let(::matrixName),
+            disabled = name?.let(::isMatrixDisabledName) ?: false,
             source = source as MatrixDataSource<Any?>,
             nameFn = nameFn as NameFn<Any?>,
             layerConfig = layerConfig,
@@ -87,7 +117,7 @@ class CompactScope internal constructor(
     }
 
     internal fun <T> dataTestInternal(
-        name: String,
+        name: String?,
         source: MatrixDataSource<T>,
         nameFn: NameFn<T>,
         replayIndexes: List<Long>?,
@@ -96,8 +126,8 @@ class CompactScope internal constructor(
     ) {
         val layerConfig = DataLayerConfigBuilder(matrixConfig).apply(configBlock).build(replayIndexes)
         nodes += VirtualNode.DataTest(
-            matrixName(name),
-            disabled = isMatrixDisabledName(name),
+            name?.let(::matrixName),
+            disabled = name?.let(::isMatrixDisabledName) ?: false,
             source = source as MatrixDataSource<Any?>,
             nameFn = nameFn as NameFn<Any?>,
             layerConfig = layerConfig,
@@ -123,8 +153,24 @@ class CompactScope internal constructor(
         config: PropertyLayerConfigBuilder.() -> Unit = {},
     ): CompactPropertyLayer<T> = property(name, gen, iterations, nameFn, listOf(replay), config)
 
+    fun <T> property(
+        gen: Gen<T>,
+        iterations: Int = matrixConfig.defaultPropertyIterations,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replays: List<ReplayInput>? = null,
+        config: PropertyLayerConfigBuilder.() -> Unit = {},
+    ): CompactPropertyLayer<T> = CompactPropertyLayer(this, null, gen, iterations, nameFn, replays, config)
+
+    fun <T> property(
+        gen: Gen<T>,
+        iterations: Int = matrixConfig.defaultPropertyIterations,
+        nameFn: NameFn<T> = { index, value -> defaultLayerName(index, value) },
+        replay: ReplayInput,
+        config: PropertyLayerConfigBuilder.() -> Unit = {},
+    ): CompactPropertyLayer<T> = property(gen, iterations, nameFn, listOf(replay), config)
+
     internal fun <T> propertyInternal(
-        name: String,
+        name: String?,
         gen: Gen<T>,
         iterations: Int,
         nameFn: NameFn<T>,
@@ -135,8 +181,8 @@ class CompactScope internal constructor(
         require(iterations >= 0) { "iterations must be >= 0" }
         val layerConfig = PropertyLayerConfigBuilder(matrixConfig).apply(config).build(replays)
         nodes += VirtualNode.Property(
-            matrixName(name),
-            disabled = isMatrixDisabledName(name),
+            name?.let(::matrixName),
+            disabled = name?.let(::isMatrixDisabledName) ?: false,
             gen = gen as Gen<Any?>,
             iterations = iterations,
             nameFn = nameFn as NameFn<Any?>,
@@ -151,7 +197,7 @@ class CompactScope internal constructor(
     }
 
     internal fun <T> propertyTestInternal(
-        name: String,
+        name: String?,
         gen: Gen<T>,
         iterations: Int,
         nameFn: NameFn<T>,
@@ -162,8 +208,8 @@ class CompactScope internal constructor(
         require(iterations >= 0) { "iterations must be >= 0" }
         val layerConfig = PropertyLayerConfigBuilder(matrixConfig).apply(config).build(replays)
         nodes += VirtualNode.PropertyTest(
-            matrixName(name),
-            disabled = isMatrixDisabledName(name),
+            name?.let(::matrixName),
+            disabled = name?.let(::isMatrixDisabledName) ?: false,
             gen = gen as Gen<Any?>,
             iterations = iterations,
             nameFn = nameFn as NameFn<Any?>,
@@ -175,7 +221,7 @@ class CompactScope internal constructor(
 
 class CompactDataLayer<T> internal constructor(
     private val scope: CompactScope,
-    private val name: String,
+    private val name: String?,
     private val source: MatrixDataSource<T>,
     private val nameFn: NameFn<T>,
     private val replayIndexes: List<Long>?,
@@ -192,7 +238,7 @@ class CompactDataLayer<T> internal constructor(
 
 class CompactPropertyLayer<T> internal constructor(
     private val scope: CompactScope,
-    private val name: String,
+    private val name: String?,
     private val gen: Gen<T>,
     private val iterations: Int,
     private val nameFn: NameFn<T>,

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixFixtureGenerator.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixFixtureGenerator.kt
@@ -35,7 +35,7 @@ class MatrixFixtureGeneratorScope<T> internal constructor(
                     matrix.config,
                     matrix.registrationPath,
                     matrix.registrationReporter,
-                    matrix.replayPath,
+                    matrix.replayPath + MatrixReplayFrame.Group(matrixName(name)),
                 ).body(generator())
             }
         }

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixModel.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixModel.kt
@@ -45,7 +45,7 @@ internal sealed interface VirtualNode {
 
     data class Test(val name: String, val disabled: Boolean, val body: suspend Test.ExecutionScope.() -> Unit) : VirtualNode
     data class Data(
-        val name: String,
+        val name: String?,
         val disabled: Boolean,
         val source: MatrixDataSource<Any?>,
         val nameFn: NameFn<Any?>,
@@ -54,7 +54,7 @@ internal sealed interface VirtualNode {
     ) : VirtualNode
 
     data class DataTest(
-        val name: String,
+        val name: String?,
         val disabled: Boolean,
         val source: MatrixDataSource<Any?>,
         val nameFn: NameFn<Any?>,
@@ -63,7 +63,7 @@ internal sealed interface VirtualNode {
     ) : VirtualNode
 
     data class Property(
-        val name: String,
+        val name: String?,
         val disabled: Boolean,
         val gen: Gen<Any?>,
         val iterations: Int,
@@ -73,7 +73,7 @@ internal sealed interface VirtualNode {
     ) : VirtualNode
 
     data class PropertyTest(
-        val name: String,
+        val name: String?,
         val disabled: Boolean,
         val gen: Gen<Any?>,
         val iterations: Int,

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixRegistrationProgress.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixRegistrationProgress.kt
@@ -51,7 +51,7 @@ private fun MatrixRegistrationProgress(
 ): MatrixRegistrationProgress {
     var registered = 0L
     var lastPrinted = -1L
-    val prefix = (path.map { it.render() } + name).joinToString(" › ")
+    val prefix = (path.map { it.render() } + name).joinToString(" ↘ ")
     fun message(): String {
         lastPrinted = registered
         return buildString {

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixReplay.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixReplay.kt
@@ -5,35 +5,60 @@ import de.infix.testBalloon.framework.core.Test
 import kotlin.AssertionError as AssertionErr
 
 /**
- * One layer's contribution to a failure's reproduction info. [Property] records the seed + iteration
- * needed to regenerate a random value; [Data] records the index of a (deterministic) data case — both
- * are needed because a custom `nameFn` may omit the index from the displayed name.
+ * One layer's contribution to a failure's path / reproduction info. [Group] is a non-replayable structural
+ * layer (a suite, a `- { }` group, or a plain `test` leaf) that only carries a path segment. [Property] and
+ * [Data] are [Replayable] layers: [Property] records the seed + iteration needed to regenerate a random value,
+ * [Data] records the index of a (deterministic) data case — both are needed because a custom `nameFn` may omit
+ * the index from the displayed name. The full frame chain mirrors the compact report path; only [Replayable]
+ * frames also emit a copy-paste replay-argument line.
  */
 internal sealed interface MatrixReplayFrame {
-    /** The layer's explicit name, or `null` for a nameless layer. */
-    val layerName: String?
-    val rowName: String
+    /** This layer's segment in the human-readable failure path (the report's top line). */
+    val pathSegment: String
 
-    /** The layer kind, always available because frames are typed (used as a `(data)`/`(property)` marker). */
-    val kind: String
+    /** A structural layer (suite / group / plain `test`) with no replayable value — path segment only. */
+    data class Group(val name: String) : MatrixReplayFrame {
+        override val pathSegment: String get() = name
+    }
+
+    /** A replayable layer (`data` / `property`) that additionally contributes a replay-argument detail line. */
+    sealed interface Replayable : MatrixReplayFrame {
+        /** The layer's explicit name, or `null` for a nameless layer. */
+        val layerName: String?
+        val rowName: String
+
+        /** The layer kind, always available because frames are typed (rendered as a `(data)`/`(property)` marker). */
+        val kind: String
+
+        /** The replay argument to paste back onto the layer, e.g. `replayIndex = 3L`. */
+        val replayArgument: String
+
+        override val pathSegment: String
+            get() = if (layerName != null) "($kind) $layerName: $rowName" else "($kind) $rowName"
+    }
 
     data class Property(
         override val layerName: String?,
         val seed: Long,
         val iteration: Long,
         override val rowName: String,
-    ) : MatrixReplayFrame {
+    ) : Replayable {
         override val kind: String get() = "property"
+        override val replayArgument: String get() = "replay = ReplayInput(seed=${seed}L, iteration=${iteration}L)"
     }
 
     data class Data(
         override val layerName: String?,
         val index: Long,
         override val rowName: String,
-    ) : MatrixReplayFrame {
+    ) : Replayable {
         override val kind: String get() = "data"
+        override val replayArgument: String get() = "replayIndex = ${index}L"
     }
 }
+
+/** Whether this frame chain has anything to replay; group-only chains produce no replay block. */
+internal fun List<MatrixReplayFrame>.hasReplayable(): Boolean = any { it is MatrixReplayFrame.Replayable }
 
 internal fun List<MatrixReplayFrame>.message(
     prefix: String = "Error replay info:",
@@ -44,35 +69,22 @@ internal fun List<MatrixReplayFrame>.message(
         append(firstLineIndent)
         append(prefix)
         append(" ")
-        appendLine(this@message.joinToString(" ↘ ") { frame ->
-            if (frame.layerName != null) "(${frame.kind}) ${frame.layerName}: ${frame.rowName}"
-            else "(${frame.kind}) ${frame.rowName}"
-        })
+        appendLine(this@message.joinToString(" ↘ ") { it.pathSegment })
         this@message.forEach { frame ->
+            if (frame !is MatrixReplayFrame.Replayable) return@forEach
             append(detailLineIndent)
             append("- (")
             append(frame.kind)
             append(")")
             if (frame.layerName != null) append(" ${frame.layerName}")
             append(": ")
-            when (frame) {
-                is MatrixReplayFrame.Property -> {
-                    append("replay = ReplayInput(seed=")
-                    append(frame.seed).append("L")
-                    append(", iteration=")
-                    append(frame.iteration).append("L)")
-                }
-                is MatrixReplayFrame.Data -> {
-                    append("replayIndex = ")
-                    append(frame.index).append("L")
-                }
-            }
+            append(frame.replayArgument)
             appendLine()
         }
     }.trimEnd()
 
 internal inline fun AssertionErr.withMatrixReplay(frames: List<MatrixReplayFrame>): AssertionErr {
-    if (frames.isEmpty() || this is AssertionError) return this
+    if (!frames.hasReplayable() || this is AssertionError) return this
     val original = message
     val replay = frames.message(firstLineIndent = "    ", detailLineIndent = "      ")
     val wrappedMessage = if (original.isNullOrBlank()) replay else "$original\n$replay"

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixReplay.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixReplay.kt
@@ -44,7 +44,7 @@ internal fun List<MatrixReplayFrame>.message(
         append(firstLineIndent)
         append(prefix)
         append(" ")
-        appendLine(this@message.joinToString(" / ") { frame ->
+        appendLine(this@message.joinToString(" ↘ ") { frame ->
             if (frame.layerName != null) "(${frame.kind}) ${frame.layerName}: ${frame.rowName}"
             else "(${frame.kind}) ${frame.rowName}"
         })

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixReplay.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixReplay.kt
@@ -10,21 +10,29 @@ import kotlin.AssertionError as AssertionErr
  * are needed because a custom `nameFn` may omit the index from the displayed name.
  */
 internal sealed interface MatrixReplayFrame {
-    val layerName: String
+    /** The layer's explicit name, or `null` for a nameless layer. */
+    val layerName: String?
     val rowName: String
 
+    /** The layer kind, always available because frames are typed (used as a `(data)`/`(property)` marker). */
+    val kind: String
+
     data class Property(
-        override val layerName: String,
+        override val layerName: String?,
         val seed: Long,
         val iteration: Long,
         override val rowName: String,
-    ) : MatrixReplayFrame
+    ) : MatrixReplayFrame {
+        override val kind: String get() = "property"
+    }
 
     data class Data(
-        override val layerName: String,
+        override val layerName: String?,
         val index: Long,
         override val rowName: String,
-    ) : MatrixReplayFrame
+    ) : MatrixReplayFrame {
+        override val kind: String get() = "data"
+    }
 }
 
 internal fun List<MatrixReplayFrame>.message(
@@ -36,20 +44,26 @@ internal fun List<MatrixReplayFrame>.message(
         append(firstLineIndent)
         append(prefix)
         append(" ")
-        appendLine(this@message.joinToString(" / ") { frame -> "${frame.layerName}: ${frame.rowName}" })
+        appendLine(this@message.joinToString(" / ") { frame ->
+            if (frame.layerName != null) "(${frame.kind}) ${frame.layerName}: ${frame.rowName}"
+            else "(${frame.kind}) ${frame.rowName}"
+        })
         this@message.forEach { frame ->
             append(detailLineIndent)
-            append("- ")
-            append(frame.layerName)
+            append("- (")
+            append(frame.kind)
+            append(")")
+            if (frame.layerName != null) append(" ${frame.layerName}")
+            append(": ")
             when (frame) {
                 is MatrixReplayFrame.Property -> {
-                    append(": replay = ReplayInput(seed=")
+                    append("replay = ReplayInput(seed=")
                     append(frame.seed).append("L")
                     append(", iteration=")
                     append(frame.iteration).append("L)")
                 }
                 is MatrixReplayFrame.Data -> {
-                    append(": replayIndex = ")
+                    append("replayIndex = ")
                     append(frame.index).append("L")
                 }
             }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixCompactReportTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixCompactReportTest.kt
@@ -120,7 +120,7 @@ val MatrixCompactResultTest by testSuite {
 
         val message = error.message!!
         message.shouldContain("  error: AssertionError: boom\n")
-        message.shouldContain("    Error replay info: (property) first: 1: alpha / (property) second: 2: beta\n")
+        message.shouldContain("    Error replay info: (property) first: 1: alpha ↘ (property) second: 2: beta\n")
         message.shouldContain("      - (property) first: replay = ReplayInput(seed=111L, iteration=1L)\n")
         message.shouldContain("      - (property) second: replay = ReplayInput(seed=222L, iteration=2L)\n")
     }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixCompactReportTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixCompactReportTest.kt
@@ -120,8 +120,8 @@ val MatrixCompactResultTest by testSuite {
 
         val message = error.message!!
         message.shouldContain("  error: AssertionError: boom\n")
-        message.shouldContain("    Error replay info: first: 1: alpha / second: 2: beta\n")
-        message.shouldContain("      - first: replay = ReplayInput(seed=111L, iteration=1L)\n")
-        message.shouldContain("      - second: replay = ReplayInput(seed=222L, iteration=2L)\n")
+        message.shouldContain("    Error replay info: (property) first: 1: alpha / (property) second: 2: beta\n")
+        message.shouldContain("      - (property) first: replay = ReplayInput(seed=111L, iteration=1L)\n")
+        message.shouldContain("      - (property) second: replay = ReplayInput(seed=222L, iteration=2L)\n")
     }
 }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixCompactScopeTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixCompactScopeTest.kt
@@ -74,4 +74,32 @@ val MatrixCompactScopeTest by testSuite {
         val node = scope.nodes.single().shouldBeInstanceOf<VirtualNode.DataTest>()
         node.layerConfig.replayIndexes shouldBe listOf(1L)
     }
+
+    test("a nameless data terminal builds a DataTest node with a null layer name") {
+        val scope = compactScope()
+        scope.data(listOf(1, 2, 3)) test {}
+        val node = scope.nodes.single().shouldBeInstanceOf<VirtualNode.DataTest>()
+        node.name shouldBe null
+        node.source.knownSize shouldBe 3L
+    }
+
+    test("a nameless data container builds a Data node with a null layer name") {
+        val scope = compactScope()
+        scope.data(listOf(1, 2)) - { }
+        scope.nodes.single().shouldBeInstanceOf<VirtualNode.Data>().name shouldBe null
+    }
+
+    test("a nameless property terminal builds a PropertyTest node with a null layer name") {
+        val scope = compactScope()
+        scope.property(Arb.of(1, 2), iterations = 7) test {}
+        val node = scope.nodes.single().shouldBeInstanceOf<VirtualNode.PropertyTest>()
+        node.name shouldBe null
+        node.iterations shouldBe 7
+    }
+
+    test("a nameless property container builds a Property node with a null layer name") {
+        val scope = compactScope()
+        scope.property(Arb.of(1, 2), iterations = 2) - { }
+        scope.nodes.single().shouldBeInstanceOf<VirtualNode.Property>().name shouldBe null
+    }
 }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixDslIntegrationTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixDslIntegrationTest.kt
@@ -91,3 +91,43 @@ val matrixCompactSharedPassingTest by matrixSuite(execution = ExecutionMode.Sequ
         }
     }
 }
+
+// Nameless `data`/`property` overloads: no leading layer name, no intermediate grouping node — the
+// per-case nodes are generated directly into the surrounding scope.
+
+val matrixNamelessNestedDataTest by matrixSuite(execution = ExecutionMode.Sequential) {
+    var leaves = 0
+    data(listOf(1, 2, 3)) - {
+        data(listOf("a", "b")) test { leaves++ }
+    }
+    "nameless nested data dimensions still produce the cartesian product" {
+        leaves shouldBe 6
+    }
+}
+
+val matrixNamelessPropertyOverDataTest by matrixSuite(execution = ExecutionMode.Sequential) {
+    var leaves = 0
+    property(Arb.of(1, 2), iterations = 2) - {
+        data(listOf(10, 20, 30)) test { leaves++ }
+    }
+    "nameless property over nameless data multiplies cases" {
+        leaves shouldBe 6
+    }
+}
+
+val matrixNamelessSequenceLimitTest by matrixSuite(execution = ExecutionMode.Sequential) {
+    var count = 0
+    data(sequenceOf(1, 2, 3, 4, 5), limit = 2) test { count++ }
+    "nameless sequence limit caps the number of cases" {
+        count shouldBe 2
+    }
+}
+
+val matrixNamelessCompactTest by matrixSuite(execution = ExecutionMode.Sequential) {
+    compact("nameless compact") { report = CompactReport.AllCases } - {
+        data(listOf(1, 2, 3)) test { it shouldBeGreaterThan 0 }
+        property(Arb.of(2, 4, 6), iterations = 3) - {
+            data(listOf(8, 10)) test { it shouldBeGreaterThan 0 }
+        }
+    }
+}

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixPropertyReplayTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixPropertyReplayTest.kt
@@ -20,9 +20,9 @@ val MatrixPropertyReplayTest by testSuite {
 
         val message = wrapped.message!!
         message.startsWith("boom\n    Error replay info:").shouldBeTrue()
-        message.contains("    Error replay info: outer: 12: alpha / inner: 417: beta").shouldBeTrue()
-        message.contains("      - outer: replay = ReplayInput(seed=111L, iteration=12L)").shouldBeTrue()
-        message.contains("      - inner: replay = ReplayInput(seed=222L, iteration=417L)").shouldBeTrue()
+        message.contains("    Error replay info: (property) outer: 12: alpha / (property) inner: 417: beta").shouldBeTrue()
+        message.contains("      - (property) outer: replay = ReplayInput(seed=111L, iteration=12L)").shouldBeTrue()
+        message.contains("      - (property) inner: replay = ReplayInput(seed=222L, iteration=417L)").shouldBeTrue()
         message.contains("boom").shouldBeTrue()
         wrapped.cause shouldBe original
     }
@@ -58,10 +58,10 @@ val MatrixPropertyReplayTest by testSuite {
 
         val message = error.message!!
         message.contains(
-            "First error replay info omitted from row report: outer: 12: alpha / inner: 417: beta"
+            "First error replay info omitted from row report: (property) outer: 12: alpha / (property) inner: 417: beta"
         ).shouldBeTrue()
-        message.contains("- outer: replay = ReplayInput(seed=111L, iteration=12L)").shouldBeTrue()
-        message.contains("- inner: replay = ReplayInput(seed=222L, iteration=417L)").shouldBeTrue()
+        message.contains("- (property) outer: replay = ReplayInput(seed=111L, iteration=12L)").shouldBeTrue()
+        message.contains("- (property) inner: replay = ReplayInput(seed=222L, iteration=417L)").shouldBeTrue()
         message.contains("Failure: row").shouldBeFalse()
     }
 }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixPropertyReplayTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixPropertyReplayTest.kt
@@ -20,7 +20,7 @@ val MatrixPropertyReplayTest by testSuite {
 
         val message = wrapped.message!!
         message.startsWith("boom\n    Error replay info:").shouldBeTrue()
-        message.contains("    Error replay info: (property) outer: 12: alpha / (property) inner: 417: beta").shouldBeTrue()
+        message.contains("    Error replay info: (property) outer: 12: alpha ↘ (property) inner: 417: beta").shouldBeTrue()
         message.contains("      - (property) outer: replay = ReplayInput(seed=111L, iteration=12L)").shouldBeTrue()
         message.contains("      - (property) inner: replay = ReplayInput(seed=222L, iteration=417L)").shouldBeTrue()
         message.contains("boom").shouldBeTrue()
@@ -58,7 +58,7 @@ val MatrixPropertyReplayTest by testSuite {
 
         val message = error.message!!
         message.contains(
-            "First error replay info omitted from row report: (property) outer: 12: alpha / (property) inner: 417: beta"
+            "First error replay info omitted from row report: (property) outer: 12: alpha ↘ (property) inner: 417: beta"
         ).shouldBeTrue()
         message.contains("- (property) outer: replay = ReplayInput(seed=111L, iteration=12L)").shouldBeTrue()
         message.contains("- (property) inner: replay = ReplayInput(seed=222L, iteration=417L)").shouldBeTrue()

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayMessageTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayMessageTest.kt
@@ -18,7 +18,7 @@ val MatrixReplayMessageTest by testSuite {
             MatrixReplayFrame.Property("p", seed = 9L, iteration = 4L, rowName = "four"),
         )
         val message = frames.message(prefix = "Repro:")
-        message.shouldStartWith("Repro: (data) d: two / (property) p: four")
+        message.shouldStartWith("Repro: (data) d: two ↘ (property) p: four")
         message.shouldContain("- (data) d: replayIndex = 2L")
         message.shouldContain("- (property) p: replay = ReplayInput(seed=9L, iteration=4L)")
     }
@@ -29,7 +29,7 @@ val MatrixReplayMessageTest by testSuite {
             MatrixReplayFrame.Property(null, seed = 9L, iteration = 4L, rowName = "four"),
         )
         val message = frames.message(prefix = "Repro:")
-        message.shouldStartWith("Repro: (data) two / (property) four")
+        message.shouldStartWith("Repro: (data) two ↘ (property) four")
         message.shouldContain("- (data): replayIndex = 2L")
         message.shouldContain("- (property): replay = ReplayInput(seed=9L, iteration=4L)")
     }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayMessageTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayMessageTest.kt
@@ -3,6 +3,7 @@ package at.asitplus.testballoon.matrix
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldStartWith
 
 /** Rendering of the "Error replay info" block and the assertion-wrapping helper. */
@@ -34,9 +35,29 @@ val MatrixReplayMessageTest by testSuite {
         message.shouldContain("- (property): replay = ReplayInput(seed=9L, iteration=4L)")
     }
 
+    test("group frames appear in the path but produce no replay-argument line") {
+        val frames = listOf(
+            MatrixReplayFrame.Group("outer group"),
+            MatrixReplayFrame.Data("d", index = 2L, rowName = "two"),
+            MatrixReplayFrame.Group("leaf"),
+        )
+        val message = frames.message(prefix = "Repro:")
+        // full path includes the structural groups...
+        message.shouldStartWith("Repro: outer group ↘ (data) d: two ↘ leaf")
+        // ...but only the replayable layer contributes a detail line
+        message.shouldContain("- (data) d: replayIndex = 2L")
+        message.shouldNotContain("outer group:")
+        message.shouldNotContain("- leaf")
+    }
+
     test("withMatrixReplay on empty frames returns the original error unchanged") {
         val original = AssertionError("boom")
         original.withMatrixReplay(emptyList()) shouldBe original
+    }
+
+    test("withMatrixReplay on a group-only path (nothing to replay) returns the original unchanged") {
+        val original = AssertionError("boom")
+        original.withMatrixReplay(listOf(MatrixReplayFrame.Group("a"), MatrixReplayFrame.Group("b"))) shouldBe original
     }
 
     test("withMatrixReplay preserves the original as the cause and keeps its message") {

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayMessageTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayMessageTest.kt
@@ -12,15 +12,26 @@ val MatrixReplayMessageTest by testSuite {
         emptyList<MatrixReplayFrame>().message() shouldBe "Error replay info:"
     }
 
-    test("message renders data and property frames with a custom prefix") {
+    test("message renders named data and property frames with their type marker") {
         val frames = listOf(
             MatrixReplayFrame.Data("d", index = 2L, rowName = "two"),
             MatrixReplayFrame.Property("p", seed = 9L, iteration = 4L, rowName = "four"),
         )
         val message = frames.message(prefix = "Repro:")
-        message.shouldStartWith("Repro: d: two / p: four")
-        message.shouldContain("- d: replayIndex = 2L")
-        message.shouldContain("- p: replay = ReplayInput(seed=9L, iteration=4L)")
+        message.shouldStartWith("Repro: (data) d: two / (property) p: four")
+        message.shouldContain("- (data) d: replayIndex = 2L")
+        message.shouldContain("- (property) p: replay = ReplayInput(seed=9L, iteration=4L)")
+    }
+
+    test("a null layer name (nameless layer) keeps the type marker but drops the name") {
+        val frames = listOf(
+            MatrixReplayFrame.Data(null, index = 2L, rowName = "two"),
+            MatrixReplayFrame.Property(null, seed = 9L, iteration = 4L, rowName = "four"),
+        )
+        val message = frames.message(prefix = "Repro:")
+        message.shouldStartWith("Repro: (data) two / (property) four")
+        message.shouldContain("- (data): replayIndex = 2L")
+        message.shouldContain("- (property): replay = ReplayInput(seed=9L, iteration=4L)")
     }
 
     test("withMatrixReplay on empty frames returns the original error unchanged") {
@@ -33,7 +44,7 @@ val MatrixReplayMessageTest by testSuite {
         val wrapped = original.withMatrixReplay(listOf(MatrixReplayFrame.Data("d", index = 0L, rowName = "0: x")))
         wrapped.cause shouldBe original
         wrapped.message!!.shouldContain("boom")
-        wrapped.message!!.shouldContain("- d: replayIndex = 0L")
+        wrapped.message!!.shouldContain("- (data) d: replayIndex = 0L")
     }
 
     test("withMatrixReplay is idempotent on an already-wrapped assertion") {

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayTest.kt
@@ -89,9 +89,9 @@ val MatrixReplayTest by testSuite {
         )
 
         val message = frames.message()
-        message.contains("Error replay info: prop: 3: x / data: no-index-here").shouldBeTrue()
-        message.contains("- prop: replay = ReplayInput(seed=7L, iteration=3L)").shouldBeTrue()
-        message.contains("- data: replayIndex = 5L").shouldBeTrue()
+        message.contains("Error replay info: (property) prop: 3: x / (data) data: no-index-here").shouldBeTrue()
+        message.contains("- (property) prop: replay = ReplayInput(seed=7L, iteration=3L)").shouldBeTrue()
+        message.contains("- (data) data: replayIndex = 5L").shouldBeTrue()
     }
 }
 

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixReplayTest.kt
@@ -89,7 +89,7 @@ val MatrixReplayTest by testSuite {
         )
 
         val message = frames.message()
-        message.contains("Error replay info: (property) prop: 3: x / (data) data: no-index-here").shouldBeTrue()
+        message.contains("Error replay info: (property) prop: 3: x ↘ (data) data: no-index-here").shouldBeTrue()
         message.contains("- (property) prop: replay = ReplayInput(seed=7L, iteration=3L)").shouldBeTrue()
         message.contains("- (data) data: replayIndex = 5L").shouldBeTrue()
     }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
@@ -179,22 +179,34 @@ val combinedFeaturesReport by matrixSuite(execution = ExecutionMode.Concurrent(1
 
 
 val showcaseReport by matrixSuite(execution = ExecutionMode.Concurrent()) {
-    property(
-        "first",
-        Arb.int(min = 1), iterations = 5, replay = ReplayInput(seed=-6390287234787975868L, iteration=2L)
-    ) - { first ->
+    "Fioibar" - {
         property(
-            "second",
-            Arb.short(min = 1), iterations = 5, replay = ReplayInput(seed=-8543743835751713023L, iteration=0L)
-        ) - { second ->
-            data(
-                "third",
-                listOf(1, 2, 3, 4, 5), replayIndex = 3L
-            ) - { third ->
+            "first",
+            Arb.int(min = 1), iterations = 5, replay = ReplayInput(seed = -6390287234787975868L, iteration = 2L)
+        ) - { first ->
+            "Baz" - {
                 property(
-                    "fourth",
-                    Arb.byte(min = 1), iterations = 5, replay = ReplayInput(seed=-1520609654322826870L, iteration=4L)
-                ) test { fourth -> (first / second / third / fourth).shouldBeLessThan(256_000) }
+                    "second",
+                    Arb.short(min = 1),
+                    iterations = 5,
+                    replay = ReplayInput(seed = -8543743835751713023L, iteration = 0L)
+                ) - { second ->
+                    compact("for testing") - {
+                        data(
+                            "third",
+                            listOf(1, 2, 3, 4, 5), replayIndex = 3L
+                        ) - { third ->
+                            property(
+                                "fourth",
+                                Arb.byte(min = 1),
+                                iterations = 5,
+                                replay = ReplayInput(seed = -1520609654322826870L, iteration = 4L)
+                            ) - { fourth ->
+                                "bonk" { (first / second / third / fourth).shouldBeLessThan(256_000) }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
@@ -179,34 +179,21 @@ val combinedFeaturesReport by matrixSuite(execution = ExecutionMode.Concurrent(1
 
 
 val showcaseReport by matrixSuite(execution = ExecutionMode.Concurrent()) {
-    "Fioibar" - {
+    property(
+        "first",
+        Arb.int(min = 1), iterations = 5, replay = ReplayInput(seed=-6390287234787975868L, iteration=2L)
+    ) - { first ->
         property(
-            "first",
-            Arb.int(min = 1), iterations = 5, replay = ReplayInput(seed = -6390287234787975868L, iteration = 2L)
-        ) - { first ->
-            "Baz" - {
+            "second",
+            Arb.short(min = 1), iterations = 5, replay = ReplayInput(seed=-8543743835751713023L, iteration=0L)
+        ) - { second ->
+            data(
+                listOf(1, 2, 3, 4, 5), replayIndex = 3L
+            ) - { third ->
                 property(
-                    "second",
-                    Arb.short(min = 1),
-                    iterations = 5,
-                    replay = ReplayInput(seed = -8543743835751713023L, iteration = 0L)
-                ) - { second ->
-                    compact("for testing") - {
-                        data(
-                            "third",
-                            listOf(1, 2, 3, 4, 5), replayIndex = 3L
-                        ) - { third ->
-                            property(
-                                "fourth",
-                                Arb.byte(min = 1),
-                                iterations = 5,
-                                replay = ReplayInput(seed = -1520609654322826870L, iteration = 4L)
-                            ) - { fourth ->
-                                "bonk" { (first / second / third / fourth).shouldBeLessThan(256_000) }
-                            }
-                        }
-                    }
-                }
+                    "fourth",
+                    Arb.byte(min = 1), iterations = 5, replay = ReplayInput(seed=-1520609654322826870L, iteration=4L)
+                ) test { fourth -> (first / second / third / fourth).shouldBeLessThan(256_000) }
             }
         }
     }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
@@ -181,18 +181,19 @@ val combinedFeaturesReport by matrixSuite(execution = ExecutionMode.Concurrent(1
 val showcaseReport by matrixSuite(execution = ExecutionMode.Concurrent()) {
     property(
         "first",
-        Arb.int(min = 1), iterations = 5, replay = ReplayInput(seed=-6390287234787975868L, iteration=2L)
+        Arb.int(min = 1), iterations = 5,
     ) - { first ->
         property(
             "second",
-            Arb.short(min = 1), iterations = 5, replay = ReplayInput(seed=-8543743835751713023L, iteration=0L)
+            Arb.short(min = 1), iterations = 5,
         ) - { second ->
-            data(
-                listOf(1, 2, 3, 4, 5), replayIndex = 3L
+            data(/*nameless third*/
+                listOf(1, 2, 3, 4, 5),
             ) - { third ->
                 property(
                     "fourth",
-                    Arb.byte(min = 1), iterations = 5, replay = ReplayInput(seed=-1520609654322826870L, iteration=4L)
+                    Arb.byte(min = 1),
+                    iterations = 5,
                 ) test { fourth -> (first / second / third / fourth).shouldBeLessThan(256_000) }
             }
         }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
@@ -167,7 +167,7 @@ val combinedFeaturesReport by matrixSuite(execution = ExecutionMode.Concurrent(1
                     report = CompactReport.AllCases
                     concurrency = CompactConcurrency.Shared(1)
                 } - {
-                    property("offset", Arb.int(0..100), iterations = 500) test { offset ->
+                    property(Arb.int(0..100), iterations = 500) test { offset ->
                         val result = fixture.size * multiplier + offset
                         result shouldBeGreaterThan 0
                     }


### PR DESCRIPTION
* **Matrix testing: nameless `data` / `property` layers**
    * `data` and `property` now have overloads that omit the leading name (e.g. `data(listOf(...)) test { ... }`,
      `property(Arb.int()) - { ... }`). A nameless layer skips the intermediate grouping node and registers its rows
      directly in the surrounding scope. A named layer remains shorthand for wrapping a nameless one in a labeled
      suite. Available in both regular and `compact` scopes, across all overloads (Iterable/Sequence,
      `replayIndex(es)` / `replay(s)`, `- { }` and `test { }`).
* **Matrix testing: replay info shows layer kind**
    * `Error replay info` frames are now tagged with their layer kind — `(property)` or `(data)` — for named and
      nameless layers alike (e.g. `(property) seed: ...`). Nameless layers print the marker without a name; the
      general failure/report path still shows no synthesized segment.
* **Matrix testing: replace layer separator slash with TestBalloon separator arrow**
* **Matrix testing: replay info shows the full path**
    * The `Error replay info` path now mirrors the compact report path in full — enclosing grouping suites
      (`"name" - { ... }`) and plain `test` leaves appear as path segments, not just the replayable `data`/`property`
      layers. Only replayable layers still emit a `- ...` argument line; group-only chains produce no replay block.