### PR TITLE
0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 0.13.0
 * **Matrix testing:***
+    * Fix `TestConfig` being re-applied at every nested matrix level. The base config (a session config captured via
+      `MatrixTestDefaults { }`, or a suite-level `testConfig`) is now applied once at the level it's set and inherited
+      to children by TestBalloon, instead of being re-chained at each nested data/property case, suite, and test. This
+      caused stateful wrappers to multiply — most visibly a session `testScope` combined with `execution = Concurrent`
+      deadlocking or aborting discovery ("did not discover any tests"), and a suite-level `aroundAll` running once per
+      case. Removed the internal `MatrixTestDefaults.testSessionConfig` capture (TestBalloon already propagates the
+      session config). Per-element `testConfig` on `test` / `testSuite` / `matrixSuite` (incl. FreeSpec forms) still
+      applies exactly once, so `aroundAll` / `aroundEach` behave as expected.
+    * `test` / `testSuite` and their FreeSpec `"name"(…)` forms now accept a full matrix config via a new
+      `matrixConfig { … }` value (e.g. `testSuite("g", matrixConfig { execution = ExecutionMode.Concurrent(8) }) { }`,
+      `"g"(matrixConfig { … }) - { }`). Unset fields inherit the enclosing scope; `testConfig` is one of the fields, so
+      the existing `testConfig =` forms are now thin wrappers around `matrixConfig { testConfig = … }`. Lets you set
+      per-subtree concurrency (and have it auto-disable the `TestScope`) without a separate `matrixSuite`. Also
+      available on the fixture-scope `test` / `testSuite` (and their FreeSpec forms). When a `matrixConfig` sets both
+      `execution = Concurrent(…)` and a `testConfig` that enables a `TestScope`, the concurrency disable wins.
+    * Matrix concurrency now auto-disables TestBalloon's virtual-time `TestScope`: any `ExecutionMode.Concurrent`
+      layer/suite and every `compact` block (both execute on real dispatchers) chain `testScope(isEnabled = false)`,
+      so concurrent/compact matrices run even under a session that enables `testScope` (the default) — no manual
+      `testScope(isEnabled = false)` needed. Sequential execution leaves the inherited `TestScope` intact.
     * Fail early nesting tests in tests instead of suites
     * Deduplicate the `data` / `property` API across the real-tree and `compact` scopes. Both now share a single
       sealed `MatrixScope` surface and one set of `data` / `property` overloads (returning `DataLayer` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
 
-## 0.13.0
-* **Matrix testing:***
+## 0.14.0
+* **Matrix testing:**
+    * **Breaking:** `matrixSuite(...)` now takes its configuration as a single `matrixConfig { … }` argument instead of
+      many named parameters:
+      `val Suite by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent(8); defaultCompactReport = … }) { … }`
+      (or `val Suite by matrixSuite { … }` with no config). This matches the per-scope `test` / `testSuite` config form.
+      Migration: wrap the former named arguments in `matrixConfig { … }`, turning `name = value, …` into
+      `name = value` lines.
+    * Why: the TestBalloon compiler plugin (observed on `1.0.0-K2.4.0-Beta2`) silently fails to discover a top-level
+      `val x by matrixSuite(...)` when the call passes named arguments **out of declaration order** with non-constant
+      values — Kotlin 2.4 lowers such a call into a temporary-introducing block, and the plugin's
+      `visitPropertyNew` only recognizes a plain `IrCall`, so the suite is dropped from discovery ("did not discover any
+      tests") or its `qualifiedPropertyName` is never injected. Collapsing the parameters into one `matrixConfig`
+      argument keeps the call site a shape the plugin always discovers, regardless of how the config fields are ordered.
+      (A standalone reproduction for the upstream framework bug lives in `repro-consumer/`.)
     * Fix `TestConfig` being re-applied at every nested matrix level. The base config (a session config captured via
       `MatrixTestDefaults { }`, or a suite-level `testConfig`) is now applied once at the level it's set and inherited
       to children by TestBalloon, instead of being re-chained at each nested data/property case, suite, and test. This
@@ -21,6 +34,9 @@
       layer/suite and every `compact` block (both execute on real dispatchers) chain `testScope(isEnabled = false)`,
       so concurrent/compact matrices run even under a session that enables `testScope` (the default) — no manual
       `testScope(isEnabled = false)` needed. Sequential execution leaves the inherited `TestScope` intact.
+
+## 0.13.0
+* **Matrix testing:***
     * Fail early nesting tests in tests instead of suites
     * Deduplicate the `data` / `property` API across the real-tree and `compact` scopes. Both now share a single
       sealed `MatrixScope` surface and one set of `data` / `property` overloads (returning `DataLayer` /

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The answer is a single DSL that keeps Kotest's excellent assertion and generator
 control over registration, execution, concurrency, compaction, reporting and replaying.
 
 ```kotlin
-val combinedFeaturesSuite by matrixSuite(execution = ExecutionMode.Concurrent(12)) {
+val combinedFeaturesSuite by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent(12) }) {
     fixture { Random.nextBytes(16) } - {
         "data, properties, fixtures, and compact reports" - { freshBytes ->
             data("multiplier", listOf(1, 2, 3)) - { multiplier ->
@@ -84,12 +84,12 @@ through those layers. When that would create too many framework test elements, `
 test while still executing and reporting the full virtual matrix. This way, you still get full insights including clickable
 stacktraces taking you to the failing assertion(s)!
 
-The top-level `matrixSuite(...) { ... }` is a regular TestBalloon suite so IDE gutter actions can discover and run it.
+The top-level `matrixSuite(matrixConfig { ... }) { ... }` is a regular TestBalloon suite so IDE gutter actions can discover and run it.
 Inside the suite, every nested layer is configured first, then either opened with `- { ... }` for more nesting or finished
 with `test { ... }` to create row test elements.
 
 ```kotlin
-val quickstart by matrixSuite(execution = ExecutionMode.Sequential) {
+val quickstart by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     data("input", listOf("foo", "bar")) - { input ->
         property("offset", Arb.int(0..100), iterations = 25) test { offset ->
             val result = "$input-$offset"
@@ -122,7 +122,7 @@ nameless overload.
 `- { ... }` when each row is a dimension that contains more layers or explicit tests.
 
 ```kotlin
-val dataDrivenMatrix by matrixSuite(execution = ExecutionMode.Sequential) {
+val dataDrivenMatrix by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     data("numbers", listOf(1, 2, 3), nameFn = { index, value -> "$index: n=$value" }) test { number ->
         number shouldBeGreaterThan 0
     }
@@ -151,10 +151,18 @@ For large compacted matrices, prefer `CompactConcurrency.Shared(n)` to use one c
 > parallelizes — any `ExecutionMode.Concurrent` layer/suite, and every `compact` block (which executes on real
 > dispatchers) — matrix automatically **disables the `TestScope`** for that scope, even if the surrounding
 > `TestSession` enabled it (the default). You therefore do **not** need `testScope(isEnabled = false)` to combine
-> matrix concurrency with the default session. This wins even over a `testConfig` you pass yourself: if your
-> `matrixConfig { … }` sets both `execution = Concurrent(…)` and a `testConfig` that enables a `TestScope`, the
-> concurrency disable takes precedence. Sequential matrix execution leaves the inherited `TestScope` untouched, so
-> virtual-time tests keep working there.
+> matrix concurrency with the default session — in fact, **leave `TestScope` enabled** (the default) and let matrix turn
+> it off only where it parallelizes. Sequential matrix execution leaves the inherited `TestScope` untouched, so a mix
+> works: sequential suites get virtual time (and its timeout), concurrent suites/compact run for real. The disable also
+> wins over a `testConfig` you pass yourself, so a `testScope(true)` on a concurrent scope is overridden.
+>
+> **Timeouts:** for a virtual-time (sequential) test, use `testScope(isEnabled = true, timeout = …)` (or the 60s
+> default). The `TestScope` timeout is **per test element**, not per suite — a large matrix is *many* tests, each with
+> its own budget, so the case *count* never drains one shared timeout; raise it only if a single case is genuinely
+> slow. **Compact and concurrent tests run with `TestScope` disabled**, so its timeout doesn't apply to them at all —
+> for a wall-clock cap there, use a real-time timeout via `aroundEachTest { action -> withTimeout(…) { action() } }`
+> (per leaf) or `aroundAll { action -> withTimeout(…) { action() } }` (per block). That's a plain `testConfig` wrapper,
+> not `invocation`/`testScope`, so it doesn't conflict with `execution`.
 
 ### Property Matrix Layers
 
@@ -162,7 +170,7 @@ For large compacted matrices, prefer `CompactConcurrency.Shared(n)` to use one c
 models, and concise generator composition, while TestBalloon owns the test tree.
 
 ```kotlin
-val propertyMatrix by matrixSuite(defaultPropertyIterations = 100) {
+val propertyMatrix by matrixSuite(matrixConfig { defaultPropertyIterations = 100 }) {
     property("bytes", Arb.byteArray(Arb.int(1, 64), Arb.byte())) {
         seed = 0xC0FFEE
         nameFn = { index, bytes -> "$index: ${bytes.size} bytes" }
@@ -181,7 +189,7 @@ Deep data/property nesting can generate very large test trees. `compact` collaps
 TestBalloon test and reports the virtual rows itself.
 
 ```kotlin
-val compactMatrix by matrixSuite(execution = ExecutionMode.Concurrent()) {
+val compactMatrix by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent() }) {
     compact("all generated checks") {
         concurrency = CompactConcurrency.Shared(16)
         report = CompactReport.FailuresOnly
@@ -300,7 +308,7 @@ closes over that suite's `value`. Nesting composes the other direction too: a `f
 once per row, and a `fixture` inside another fixture's suite threads both values down to the leaves.
 
 ```kotlin
-val fixtureMatrix by matrixSuite(execution = ExecutionMode.Concurrent()) {
+val fixtureMatrix by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent() }) {
     fixture { Random.nextBytes(16) } - {
         "regular test with fresh bytes" { bytes ->        // fresh value, this test only
             bytes.size shouldBe 16
@@ -351,8 +359,15 @@ value to set concurrency (and any other matrix setting) for that subtree. Unset 
 forms shown above are just a shorthand wrapping `matrixConfig { testConfig = … }`. The fixture-scope `test` / `testSuite`
 (and their FreeSpec forms, inside `fixture { … } - { … }`) accept `matrixConfig { … }` the same way.
 
+> ⚠️ **Set concurrency with `execution`, not a `testConfig`.** A `testConfig` is for `aroundAll` / `aroundEach` /
+> context / timeout wrappers. **Never** put `TestConfig.invocation(...)` in a matrix `testConfig` — matrix derives
+> invocation from `execution`, can't strip a conflicting one out of an (opaque) `TestConfig`, and the clash can break
+> test discovery ("did not discover any tests"). Likewise, a virtual-time `testScope(...)` only applies to *sequential*
+> execution (matrix disables it when concurrent), so enable `TestScope` on the `TestSession`, not per matrix scope.
+> Wrong: `matrixSuite(matrixConfig { testConfig = TestConfig.invocation(Sequential) })`. Right: `matrixSuite(matrixConfig { execution = ExecutionMode.Sequential })`.
+
 ```kotlin
-val perScopeConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+val perScopeConfig by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     // run just this group's children concurrently (also auto-disables the TestScope — see the concurrency note above)
     testSuite("heavy group", matrixConfig { execution = ExecutionMode.Concurrent(8) }) {
         data(1..1000) test { /* … */ }
@@ -365,10 +380,10 @@ val perScopeConfig by matrixSuite(execution = ExecutionMode.Sequential) {
 ```
 
 ```kotlin
-val configuredMatrix by matrixSuite(
-    execution = ExecutionMode.Concurrent(parallelism = 4),
-    defaultPropertyIterations = 50,
-) {
+val configuredMatrix by matrixSuite(matrixConfig {
+    execution = ExecutionMode.Concurrent(parallelism = 4)
+    defaultPropertyIterations = 50
+}) {
     test("explicit test", testConfig = TestConfig) {
         // green code
     }

--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ Layer config is written as the trailing lambda before `test` or `-`. For `data`,
 Concurrency bounds are per layer: nested concurrent layers can multiply the number of active tests or virtual checks.
 For large compacted matrices, prefer `CompactConcurrency.Shared(n)` to use one compact-wide worker budget.
 
+> **Concurrency and `TestScope`.** Real concurrency cannot run inside TestBalloon's virtual-time `TestScope`
+> (TestBalloon forbids the combination, as it can deadlock through thread starvation). So wherever matrix
+> parallelizes — any `ExecutionMode.Concurrent` layer/suite, and every `compact` block (which executes on real
+> dispatchers) — matrix automatically **disables the `TestScope`** for that scope, even if the surrounding
+> `TestSession` enabled it (the default). You therefore do **not** need `testScope(isEnabled = false)` to combine
+> matrix concurrency with the default session. This wins even over a `testConfig` you pass yourself: if your
+> `matrixConfig { … }` sets both `execution = Concurrent(…)` and a `testConfig` that enables a `TestScope`, the
+> concurrency disable takes precedence. Sequential matrix execution leaves the inherited `TestScope` untouched, so
+> virtual-time tests keep working there.
+
 ### Property Matrix Layers
 
 `property` layers use Kotest generators directly. You get Kotest's `Arb` ecosystem, edge cases, shrinking-friendly data
@@ -334,6 +344,25 @@ object ProjectTestSessionConfig : TestSession(testConfig = TestConfig.apply {
 
 Individual suites can override those defaults with `matrixSuite` parameters. Layers can override their own execution or
 generation settings. Real tests and suites also accept `TestConfig`, which is chained onto the current matrix config.
+
+`test`, `testSuite`, and their FreeSpec `"name"(…)` forms accept a full matrix config too — pass a `matrixConfig { … }`
+value to set concurrency (and any other matrix setting) for that subtree. Unset fields inherit the enclosing scope, and
+`testConfig` is one of the fields (so `matrixConfig { testConfig = … }` covers `aroundAll` etc.). The `testConfig`-only
+forms shown above are just a shorthand wrapping `matrixConfig { testConfig = … }`. The fixture-scope `test` / `testSuite`
+(and their FreeSpec forms, inside `fixture { … } - { … }`) accept `matrixConfig { … }` the same way.
+
+```kotlin
+val perScopeConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+    // run just this group's children concurrently (also auto-disables the TestScope — see the concurrency note above)
+    testSuite("heavy group", matrixConfig { execution = ExecutionMode.Concurrent(8) }) {
+        data(1..1000) test { /* … */ }
+    }
+    "freespec group"(matrixConfig { execution = ExecutionMode.Concurrent(4) }) - {
+        "child" { /* … */ }
+    }
+    test("one heavy test", matrixConfig { execution = ExecutionMode.Concurrent(2) }) { /* … */ }
+}
+```
 
 ```kotlin
 val configuredMatrix by matrixSuite(

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -Xms200m
 kotlin.daemon.jvm.options=-Xmx10G -Xms200m
 kotlin.daemon.jvmargs=-Xmx10g -Xms200m
-artifactVersion = 0.13.0
+artifactVersion = 0.14.0
 jdk.version=17
 android.minSdk=21
 android.compileSdk=34

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/Matrix.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/Matrix.kt
@@ -18,32 +18,29 @@ annotation class MatrixTestDsl
 
 typealias NameFn<T> = (index: Long, value: T) -> String
 
+/**
+ * Declares a top-level matrix test suite.
+ *
+ * Pass per-suite configuration with [matrixConfig], e.g.
+ * `val Suite by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent(8) }) { … }`. Unset fields fall back
+ * to the global [MatrixTestDefaults]. With no configuration, write `val Suite by matrixSuite { … }`.
+ *
+ * The config's `testConfig` is for `aroundAll` / `aroundEach` / context / timeout wrappers only. Set concurrency via
+ * its `execution`, **never** `TestConfig.invocation(...)` — matrix derives invocation from `execution`, and a
+ * conflicting one is overridden (it cannot be removed; TestBalloon configs are opaque). A virtual-time `testScope(...)`
+ * applies only to *sequential* execution (matrix auto-disables it when concurrent); prefer enabling `TestScope` on the
+ * `TestSession`, and use `aroundEach`/`aroundAll` + `withTimeout` for timeouts under concurrency.
+ *
+ * Note: configuration is taken as a single [MatrixSuiteConfigBuilder] argument rather than many named parameters, so
+ * the call site stays a shape the TestBalloon compiler plugin reliably discovers (a plain call, not a reordered-named-
+ * argument call that the plugin can drop from discovery).
+ */
 @TestRegistering
 fun matrixSuite(
+    config: MatrixSuiteConfigBuilder = matrixConfig {},
     @TestSuitePropertyName propertyName: String = "",
-    execution: ExecutionMode? = null,
-    defaultPropertyIterations: Int? = null,
-    defaultCompactConcurrency: CompactConcurrency? = null,
-    defaultCompactReport: CompactReport? = null,
-    defaultCompactAddSuppressedErrors: Boolean? = null,
-    defaultCompactReportRows: Int? = null,
-    defaultProgressIndicator: Indicator? = null,
-    defaultCompactCoroutineContext: CoroutineContext? = null,
-    defaultTestNameMaxLength: Int? = null,
-    testConfig: TestConfig? = null,
     body: MatrixSuiteScope.() -> Unit,
-) = MatrixSuiteConfigBuilder().apply {
-    this.execution = execution
-    this.defaultPropertyIterations = defaultPropertyIterations
-    this.defaultCompactConcurrency = defaultCompactConcurrency
-    this.defaultCompactReport = defaultCompactReport
-    this.defaultCompactAddSuppressedErrors = defaultCompactAddSuppressedErrors
-    this.defaultCompactReportRows = defaultCompactReportRows
-    this.defaultProgressIndicator = defaultProgressIndicator
-    this.defaultCompactCoroutineContext = defaultCompactCoroutineContext
-    this.defaultTestNameMaxLength = defaultTestNameMaxLength
-    this.testConfig = testConfig
-}.build().let { resolved ->
+) = config.build().let { resolved ->
     testSuite(
         qualifiedPropertyName = propertyName,
         testConfig = resolved.testConfig,
@@ -101,7 +98,11 @@ data class MatrixSuiteScope internal constructor(
         }
     }
 
-    /** Shorthand for the most common case — wraps [matrixConfig] with only a [testConfig] (e.g. for `aroundAll`). */
+    /**
+     * Shorthand wrapping [matrixConfig] with only a [testConfig] (`aroundAll` / `aroundEach` / context / timeouts).
+     * Set concurrency via `execution` (see [matrixConfig]), not `TestConfig.invocation(...)`; `testScope(...)` is
+     * sequential-only (matrix disables it when concurrent).
+     */
     @TestRegistering
     fun testSuite(
         name: String,
@@ -126,6 +127,10 @@ data class MatrixSuiteScope internal constructor(
         }
     }
 
+    /**
+     * Shorthand; [testConfig] is for `aroundAll` / `aroundEach` / context / timeouts only. Set concurrency via
+     * `execution` (see [matrixConfig]), not `TestConfig.invocation(...)`; `testScope(...)` is sequential-only.
+     */
     @TestRegistering
     fun test(
         name: String,
@@ -141,6 +146,11 @@ data class MatrixSuiteScope internal constructor(
         test(this, config, body)
     }
 
+    /**
+     * FreeSpec test. [testConfig] is for `aroundAll` / `aroundEach` / context / timeouts only — set concurrency via
+     * `execution` (use the `matrixConfig` overload), not `TestConfig.invocation(...)`; `testScope(...)` is
+     * sequential-only.
+     */
     @TestRegistering
     operator fun String.invoke(
         testConfig: TestConfig = TestConfig,
@@ -154,6 +164,11 @@ data class MatrixSuiteScope internal constructor(
         config: MatrixSuiteConfigBuilder,
     ): MatrixConfiguredSuite = MatrixConfiguredSuite(this@MatrixSuiteScope, this, config)
 
+    /**
+     * FreeSpec suite (`"name"(testConfig) - { … }`). [testConfig] is for `aroundAll` / `aroundEach` / context /
+     * timeouts only — set concurrency via `execution` (use the `matrixConfig` overload), not
+     * `TestConfig.invocation(...)`; `testScope(...)` is sequential-only.
+     */
     @TestRegistering
     operator fun String.invoke(
         testConfig: TestConfig = TestConfig,

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/Matrix.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/Matrix.kt
@@ -5,6 +5,7 @@ import at.asitplus.testballoon.withCompactProgressHeartbeatSuspending
 import de.infix.testBalloon.framework.core.Test
 import de.infix.testBalloon.framework.core.TestConfig
 import de.infix.testBalloon.framework.core.TestSuiteScope
+import de.infix.testBalloon.framework.core.testScope
 import de.infix.testBalloon.framework.core.testSuite
 import de.infix.testBalloon.framework.shared.TestRegistering
 import de.infix.testBalloon.framework.shared.TestSuitePropertyName
@@ -79,18 +80,19 @@ data class MatrixSuiteScope internal constructor(
     @TestRegistering
     fun testSuite(
         name: String,
-        testConfig: TestConfig = TestConfig,
+        config: MatrixSuiteConfigBuilder,
         body: MatrixSuiteScope.() -> Unit,
     ) {
         requireOpen(name)
+        val resolved = config.build(this@MatrixSuiteScope.config)
         target.apply {
             testSuite(
                 name = matrixName(name),
-                testConfig = config.testConfig.chainedWith(testConfig).disableByMatrixName(name),
+                testConfig = resolved.testConfig.disableByMatrixName(name),
             ) {
                 MatrixSuiteScope(
                     this,
-                    config,
+                    resolved.nested(resolved.execution),
                     registrationPath,
                     registrationReporter,
                     replayPath + MatrixReplayFrame.Group(matrixName(name)),
@@ -99,20 +101,44 @@ data class MatrixSuiteScope internal constructor(
         }
     }
 
+    /** Shorthand for the most common case — wraps [matrixConfig] with only a [testConfig] (e.g. for `aroundAll`). */
+    @TestRegistering
+    fun testSuite(
+        name: String,
+        testConfig: TestConfig = TestConfig,
+        body: MatrixSuiteScope.() -> Unit,
+    ) = testSuite(name, matrixConfig { this.testConfig = testConfig }, body)
+
+    @TestRegistering
+    fun test(
+        name: String,
+        config: MatrixSuiteConfigBuilder,
+        body: suspend Test.ExecutionScope.() -> Unit,
+    ) {
+        requireOpen(name)
+        val resolved = config.build(this@MatrixSuiteScope.config)
+        target.apply {
+            test(
+                name = matrixName(name),
+                testConfig = resolved.testConfig.disableByMatrixName(name),
+                action = { withMatrixReplay(replayPath + MatrixReplayFrame.Group(matrixName(name)), body) },
+            )
+        }
+    }
+
     @TestRegistering
     fun test(
         name: String,
         testConfig: TestConfig = TestConfig,
         body: suspend Test.ExecutionScope.() -> Unit,
+    ) = test(name, matrixConfig { this.testConfig = testConfig }, body)
+
+    @TestRegistering
+    operator fun String.invoke(
+        config: MatrixSuiteConfigBuilder,
+        body: suspend Test.ExecutionScope.() -> Unit,
     ) {
-        requireOpen(name)
-        target.apply {
-            test(
-                name = matrixName(name),
-                testConfig = config.testConfig.chainedWith(testConfig).disableByMatrixName(name),
-                action = { withMatrixReplay(replayPath + MatrixReplayFrame.Group(matrixName(name)), body) },
-            )
-        }
+        test(this, config, body)
     }
 
     @TestRegistering
@@ -125,12 +151,17 @@ data class MatrixSuiteScope internal constructor(
 
     @TestRegistering
     operator fun String.invoke(
+        config: MatrixSuiteConfigBuilder,
+    ): MatrixConfiguredSuite = MatrixConfiguredSuite(this@MatrixSuiteScope, this, config)
+
+    @TestRegistering
+    operator fun String.invoke(
         testConfig: TestConfig = TestConfig,
-    ): MatrixConfiguredSuite = MatrixConfiguredSuite(this@MatrixSuiteScope, this, testConfig)
+    ): MatrixConfiguredSuite = MatrixConfiguredSuite(this@MatrixSuiteScope, this, matrixConfig { this.testConfig = testConfig })
 
     @TestRegistering
     infix operator fun MatrixConfiguredSuite.minus(body: MatrixSuiteScope.() -> Unit) {
-        scope.testSuite(name, testConfig, body)
+        scope.testSuite(name, config, body)
     }
 
     @TestRegistering
@@ -149,7 +180,7 @@ data class MatrixSuiteScope internal constructor(
         requireOpen(name)
         val layerName = name?.let(::matrixName)
         val registrationName = layerName ?: spec.defaultName
-        val scopedConfig = config.copy(execution = spec.execution)
+        val scopedConfig = config.nested(spec.execution)
         val caseTestConfig = scopedConfig.testConfig.boundBy(spec.execution.caseLimiter())
         val register: TestSuiteScope.() -> Unit = {
             val progress = registrationProgress(registrationName, spec.registrationProgressTotal, registrationPath, registrationReporter)
@@ -203,7 +234,9 @@ data class MatrixSuiteScope internal constructor(
         planningScope.building { planningScope.body() }
         val nodes = planningScope.nodes.toList()
         target.apply {
-            test(name = matrixName(name), testConfig = this@MatrixSuiteScope.config.testConfig.disableByMatrixName(name)) {
+            // Compact executes its cases on real dispatchers (its own worker pool / per-layer concurrency), so it
+            // cannot run in a virtual-time TestScope — disable it here even when the surrounding session enabled it.
+            test(name = matrixName(name), testConfig = this@MatrixSuiteScope.config.invocationConfig.testScope(isEnabled = false).disableByMatrixName(name)) {
                 val run = CompactRun(name, compactConfig)
                 when (val progress = compactConfig.progressIndicator) {
                     is Indicator.Heartbeat -> withCompactProgressHeartbeatSuspending(
@@ -224,7 +257,7 @@ data class MatrixSuiteScope internal constructor(
 class MatrixConfiguredSuite internal constructor(
     internal val scope: MatrixSuiteScope,
     internal val name: String,
-    internal val testConfig: TestConfig,
+    internal val config: MatrixSuiteConfigBuilder,
 )
 
 /**

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixConfig.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixConfig.kt
@@ -81,6 +81,16 @@ class MatrixSuiteConfigBuilder internal constructor() {
     var defaultProgressIndicator: Indicator? = null
     var defaultCompactCoroutineContext: CoroutineContext? = null
     var defaultTestNameMaxLength: Int? = null
+
+    /**
+     * A `TestConfig` for `aroundAll` / `aroundEach` / context / timeout wrappers.
+     *
+     * Set concurrency via [execution], **never** `TestConfig.invocation(...)`: matrix derives invocation from
+     * [execution], and a conflicting one here can't be removed (TestBalloon configs are opaque) — it is overridden and
+     * can break test discovery. A virtual-time `testScope(...)` applies only to *sequential* execution (matrix
+     * auto-disables it under concurrent [execution]); prefer enabling `TestScope` on the `TestSession`, and for a
+     * timeout under concurrency use `aroundEach`/`aroundAll` + `withTimeout` rather than `testScope`'s timeout.
+     */
     var testConfig: TestConfig? = null
 
     // Unset fields fall back to [parent] (the enclosing matrix scope) when given, otherwise the global defaults.
@@ -112,6 +122,11 @@ class MatrixSuiteConfigBuilder internal constructor() {
  * Builds a reusable matrix configuration value to pass to `test` / `testSuite` (and their FreeSpec `"name"(…)` forms),
  * e.g. `testSuite("group", matrixConfig { execution = ExecutionMode.Concurrent(4) }) { … }`. Unset fields inherit the
  * enclosing matrix scope. `testConfig` is one of the fields, so this also carries `aroundAll` / `aroundEach` / context.
+ *
+ * Set concurrency via `execution`, **not** `testConfig = TestConfig.invocation(...)` (matrix derives invocation from
+ * `execution`; a conflicting one is overridden and can break discovery). A `testScope(...)` (virtual time) applies only
+ * to sequential execution — matrix auto-disables it when concurrent — so prefer enabling `TestScope` on the
+ * `TestSession`, and use `aroundEach`/`aroundAll` + `withTimeout` for timeouts under concurrency.
  */
 fun matrixConfig(block: MatrixSuiteConfigBuilder.() -> Unit): MatrixSuiteConfigBuilder =
     MatrixSuiteConfigBuilder().apply(block)

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixConfig.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixConfig.kt
@@ -2,6 +2,7 @@ package at.asitplus.testballoon.matrix
 
 import de.infix.testBalloon.framework.core.TestConfig
 import de.infix.testBalloon.framework.core.invocation
+import de.infix.testBalloon.framework.core.testScope
 import io.kotest.property.EdgeConfig
 import io.kotest.property.default
 import kotlinx.coroutines.Dispatchers
@@ -20,7 +21,6 @@ internal object MatrixTestDefaults {
     var defaultProgressIndicator: Indicator = Indicator.Heartbeat(every = 1.seconds)
     var defaultCompactCoroutineContext: CoroutineContext = Dispatchers.Default
     var defaultTestNameMaxLength: Int = 256
-    var testSessionConfig: TestConfig = TestConfig
 }
 
 sealed interface ExecutionMode {
@@ -67,7 +67,6 @@ fun TestConfig.MatrixTestDefaults(config: MatrixSuiteConfigBuilder.() -> Unit) {
         MatrixTestDefaults.defaultTestNameMaxLength = suiteConfig.defaultTestNameMaxLength
         MatrixTestDefaults.defaultProgressIndicator = suiteConfig.defaultProgressIndicator
         MatrixTestDefaults.defaultCompactCoroutineContext = suiteConfig.defaultCompactCoroutineContext
-        MatrixTestDefaults.testSessionConfig = this
     }
 }
 
@@ -82,27 +81,40 @@ class MatrixSuiteConfigBuilder internal constructor() {
     var defaultProgressIndicator: Indicator? = null
     var defaultCompactCoroutineContext: CoroutineContext? = null
     var defaultTestNameMaxLength: Int? = null
-    internal var testConfig: TestConfig? = null
+    var testConfig: TestConfig? = null
 
-    internal fun build(): MatrixSuiteConfig {
-        val executionMode = execution ?: MatrixTestDefaults.execution
-        return MatrixSuiteConfig(
-            execution = executionMode,
-            defaultPropertyIterations = defaultPropertyIterations ?: MatrixTestDefaults.defaultPropertyIterations,
-            defaultCompactConcurrency = defaultCompactConcurrency ?: MatrixTestDefaults.defaultCompactConcurrency,
-            defaultCompactReport = defaultCompactReport ?: MatrixTestDefaults.defaultCompactReport,
+    // Unset fields fall back to [parent] (the enclosing matrix scope) when given, otherwise the global defaults.
+    internal fun build(parent: MatrixSuiteConfig? = null): MatrixSuiteConfig =
+        MatrixSuiteConfig(
+            execution = execution ?: parent?.execution ?: MatrixTestDefaults.execution,
+            defaultPropertyIterations = defaultPropertyIterations
+                ?: parent?.defaultPropertyIterations ?: MatrixTestDefaults.defaultPropertyIterations,
+            defaultCompactConcurrency = defaultCompactConcurrency
+                ?: parent?.defaultCompactConcurrency ?: MatrixTestDefaults.defaultCompactConcurrency,
+            defaultCompactReport = defaultCompactReport
+                ?: parent?.defaultCompactReport ?: MatrixTestDefaults.defaultCompactReport,
             defaultCompactAddSuppressedErrors = defaultCompactAddSuppressedErrors
-                ?: MatrixTestDefaults.defaultCompactAddSuppressedErrors,
-            defaultCompactReportRows = defaultCompactReportRows ?: MatrixTestDefaults.defaultCompactReportRows,
-            defaultProgressIndicator = defaultProgressIndicator ?: MatrixTestDefaults.defaultProgressIndicator,
+                ?: parent?.defaultCompactAddSuppressedErrors ?: MatrixTestDefaults.defaultCompactAddSuppressedErrors,
+            defaultCompactReportRows = defaultCompactReportRows
+                ?: parent?.defaultCompactReportRows ?: MatrixTestDefaults.defaultCompactReportRows,
+            defaultProgressIndicator = defaultProgressIndicator
+                ?: parent?.defaultProgressIndicator ?: MatrixTestDefaults.defaultProgressIndicator,
             defaultCompactCoroutineContext = defaultCompactCoroutineContext
-                ?: MatrixTestDefaults.defaultCompactCoroutineContext,
-            defaultTestNameMaxLength = defaultTestNameMaxLength ?: MatrixTestDefaults.defaultTestNameMaxLength,
-            config = (testConfig?.let { MatrixTestDefaults.testSessionConfig.chainedWith(it) }
-                ?: MatrixTestDefaults.testSessionConfig),
+                ?: parent?.defaultCompactCoroutineContext ?: MatrixTestDefaults.defaultCompactCoroutineContext,
+            defaultTestNameMaxLength = defaultTestNameMaxLength
+                ?: parent?.defaultTestNameMaxLength ?: MatrixTestDefaults.defaultTestNameMaxLength,
+            // Only this scope's own testConfig; the parent's is inherited structurally by TestBalloon, not re-applied.
+            config = testConfig ?: TestConfig,
         )
-    }
 }
+
+/**
+ * Builds a reusable matrix configuration value to pass to `test` / `testSuite` (and their FreeSpec `"name"(…)` forms),
+ * e.g. `testSuite("group", matrixConfig { execution = ExecutionMode.Concurrent(4) }) { … }`. Unset fields inherit the
+ * enclosing matrix scope. `testConfig` is one of the fields, so this also carries `aroundAll` / `aroundEach` / context.
+ */
+fun matrixConfig(block: MatrixSuiteConfigBuilder.() -> Unit): MatrixSuiteConfigBuilder =
+    MatrixSuiteConfigBuilder().apply(block)
 
 data class MatrixSuiteConfig internal constructor(
     val execution: ExecutionMode,
@@ -116,14 +128,28 @@ data class MatrixSuiteConfig internal constructor(
     val defaultTestNameMaxLength: Int,
     private var config: TestConfig,
 ) {
-    val testConfig: TestConfig by lazy {
-        config.chainedWith(
-            when (execution) {
-                is ExecutionMode.Concurrent -> TestConfig.invocation(TestConfig.Invocation.Concurrent)
-                ExecutionMode.Sequential -> TestConfig.invocation(TestConfig.Invocation.Sequential)
-            }
-        )
-    }
+    /**
+     * Just this scope's invocation (Sequential/Concurrent) — idempotent, so it is safe to apply at every level.
+     * Concurrent execution additionally disables TestBalloon's virtual-time `TestScope`: real concurrency cannot run
+     * in a `TestScope` (TestBalloon forbids the combination), so matrix turns the scope off wherever it parallelizes,
+     * even when the surrounding session enabled it. Sequential execution leaves the inherited scope untouched.
+     */
+    internal val invocationConfig: TestConfig
+        get() = when (execution) {
+            is ExecutionMode.Concurrent ->
+                TestConfig.invocation(TestConfig.Invocation.Concurrent).testScope(isEnabled = false)
+            ExecutionMode.Sequential -> TestConfig.invocation(TestConfig.Invocation.Sequential)
+        }
+
+    /** The base [config] plus invocation — applied ONCE, at the top level of a matrix suite. */
+    val testConfig: TestConfig by lazy { config.chainedWith(invocationConfig) }
+
+    /**
+     * Config for a NESTED matrix scope: drops the base [config]. TestBalloon already inherits a parent element's
+     * config to its children structurally, so re-applying the base at each nested matrix level would multiply
+     * stateful wrappers (`testScope`, `aroundAll`, …). Only the per-layer [execution] differs.
+     */
+    internal fun nested(execution: ExecutionMode): MatrixSuiteConfig = copy(execution = execution, config = TestConfig)
 }
 
 

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixFixtureGenerator.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixFixtureGenerator.kt
@@ -13,6 +13,15 @@ class MatrixFixtureGeneratorScope<T> internal constructor(
     @TestRegistering
     fun test(
         name: String,
+        config: MatrixSuiteConfigBuilder,
+        body: suspend Test.ExecutionScope.(T) -> Unit,
+    ) {
+        matrix.test(name, config) { body(generator()) }
+    }
+
+    @TestRegistering
+    fun test(
+        name: String,
         testConfig: TestConfig = TestConfig,
         body: suspend Test.ExecutionScope.(T) -> Unit,
     ) {
@@ -22,25 +31,41 @@ class MatrixFixtureGeneratorScope<T> internal constructor(
     @TestRegistering
     fun testSuite(
         name: String,
-        testConfig: TestConfig = TestConfig,
+        config: MatrixSuiteConfigBuilder,
         body: MatrixSuiteScope.(T) -> Unit,
     ) {
         matrix.requireOpen(name)
+        val resolved = config.build(matrix.config)
         matrix.target.apply {
             testSuite(
                 name = matrixName(name),
-                testConfig = matrix.config.testConfig.chainedWith(testConfig).disableByMatrixName(name),
+                testConfig = resolved.testConfig.disableByMatrixName(name),
             ) {
                 val value = generator()
                 MatrixSuiteScope(
                     this,
-                    matrix.config,
+                    resolved.nested(resolved.execution),
                     matrix.registrationPath,
                     matrix.registrationReporter,
                     matrix.replayPath + MatrixReplayFrame.Group(matrixName(name)),
                 ).apply { building { body(value) } }
             }
         }
+    }
+
+    @TestRegistering
+    fun testSuite(
+        name: String,
+        testConfig: TestConfig = TestConfig,
+        body: MatrixSuiteScope.(T) -> Unit,
+    ) = testSuite(name, matrixConfig { this.testConfig = testConfig }, body)
+
+    @TestRegistering
+    operator fun String.invoke(
+        config: MatrixSuiteConfigBuilder,
+        body: suspend Test.ExecutionScope.(T) -> Unit,
+    ) {
+        test(this, config, body)
     }
 
     @TestRegistering
@@ -53,12 +78,18 @@ class MatrixFixtureGeneratorScope<T> internal constructor(
 
     @TestRegistering
     operator fun String.invoke(
+        config: MatrixSuiteConfigBuilder,
+    ): MatrixFixtureConfiguredSuite<T> = MatrixFixtureConfiguredSuite(this@MatrixFixtureGeneratorScope, this, config)
+
+    @TestRegistering
+    operator fun String.invoke(
         testConfig: TestConfig = TestConfig,
-    ): MatrixFixtureConfiguredSuite<T> = MatrixFixtureConfiguredSuite(this@MatrixFixtureGeneratorScope, this, testConfig)
+    ): MatrixFixtureConfiguredSuite<T> =
+        MatrixFixtureConfiguredSuite(this@MatrixFixtureGeneratorScope, this, matrixConfig { this.testConfig = testConfig })
 
     @TestRegistering
     infix operator fun MatrixFixtureConfiguredSuite<T>.minus(body: MatrixSuiteScope.(T) -> Unit) {
-        scope.testSuite(name, testConfig, body)
+        scope.testSuite(name, config, body)
     }
 
     @TestRegistering
@@ -70,7 +101,7 @@ class MatrixFixtureGeneratorScope<T> internal constructor(
 class MatrixFixtureConfiguredSuite<T> internal constructor(
     internal val scope: MatrixFixtureGeneratorScope<T>,
     internal val name: String,
-    internal val testConfig: TestConfig,
+    internal val config: MatrixSuiteConfigBuilder,
 )
 
 @MatrixTestDsl

--- a/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixFixtureGenerator.kt
+++ b/matrix/src/commonMain/kotlin/at/asitplus/testballoon/matrix/MatrixFixtureGenerator.kt
@@ -19,6 +19,10 @@ class MatrixFixtureGeneratorScope<T> internal constructor(
         matrix.test(name, config) { body(generator()) }
     }
 
+    /**
+     * [testConfig] is for `aroundAll` / `aroundEach` / context / timeouts only. Set concurrency via `execution` (the
+     * `matrixConfig` overload), not `TestConfig.invocation(...)`; `testScope(...)` is sequential-only.
+     */
     @TestRegistering
     fun test(
         name: String,
@@ -53,6 +57,10 @@ class MatrixFixtureGeneratorScope<T> internal constructor(
         }
     }
 
+    /**
+     * [testConfig] is for `aroundAll` / `aroundEach` / context / timeouts only. Set concurrency via `execution` (the
+     * `matrixConfig` overload), not `TestConfig.invocation(...)`; `testScope(...)` is sequential-only.
+     */
     @TestRegistering
     fun testSuite(
         name: String,
@@ -68,6 +76,10 @@ class MatrixFixtureGeneratorScope<T> internal constructor(
         test(this, config, body)
     }
 
+    /**
+     * [testConfig] is for `aroundAll` / `aroundEach` / context / timeouts only. Set concurrency via `execution` (the
+     * `matrixConfig` overload), not `TestConfig.invocation(...)`; `testScope(...)` is sequential-only.
+     */
     @TestRegistering
     operator fun String.invoke(
         testConfig: TestConfig = TestConfig,
@@ -81,6 +93,10 @@ class MatrixFixtureGeneratorScope<T> internal constructor(
         config: MatrixSuiteConfigBuilder,
     ): MatrixFixtureConfiguredSuite<T> = MatrixFixtureConfiguredSuite(this@MatrixFixtureGeneratorScope, this, config)
 
+    /**
+     * [testConfig] is for `aroundAll` / `aroundEach` / context / timeouts only. Set concurrency via `execution` (the
+     * `matrixConfig` overload), not `TestConfig.invocation(...)`; `testScope(...)` is sequential-only.
+     */
     @TestRegistering
     operator fun String.invoke(
         testConfig: TestConfig = TestConfig,

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixCompactConcurrencyTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixCompactConcurrencyTest.kt
@@ -26,10 +26,10 @@ val MatrixCompactConcurrencyConfigTest by testSuite {
     }
 }
 
-val MatrixCompactSharedConcurrencyTest by matrixSuite(
-    execution = ExecutionMode.Sequential,
-    defaultProgressIndicator = Indicator.None,
-) {
+val MatrixCompactSharedConcurrencyTest by matrixSuite(matrixConfig {
+        execution = ExecutionMode.Sequential
+        defaultProgressIndicator = Indicator.None
+    }) {
     val mutex = Mutex()
     var active = 0
     var maxActive = 0

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixConcurrencyTestScopeTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixConcurrencyTestScopeTest.kt
@@ -1,0 +1,30 @@
+package at.asitplus.testballoon.matrix
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlin.coroutines.coroutineContext
+
+// The matrix test module runs under the default session, which enables TestBalloon's virtual-time TestScope.
+// Matrix concurrency must disable it so real concurrent / compact execution works (TestScope + concurrency is
+// forbidden by TestBalloon and otherwise deadlocks). Sequential execution leaves the inherited scope intact.
+
+val concurrentMatrixDisablesTestScope by matrixSuite(execution = ExecutionMode.Concurrent(2)) {
+    "concurrent execution disables the virtual-time TestScope" {
+        coroutineContext[TestCoroutineScheduler].shouldBeNull()
+    }
+}
+
+val sequentialMatrixKeepsTestScope by matrixSuite(execution = ExecutionMode.Sequential) {
+    "sequential execution keeps the inherited TestScope" {
+        coroutineContext[TestCoroutineScheduler].shouldNotBeNull()
+    }
+}
+
+val compactDisablesTestScope by matrixSuite {
+    compact("c") - {
+        "compact execution disables the virtual-time TestScope" {
+            coroutineContext[TestCoroutineScheduler].shouldBeNull()
+        }
+    }
+}

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixConcurrencyTestScopeTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixConcurrencyTestScopeTest.kt
@@ -9,13 +9,13 @@ import kotlin.coroutines.coroutineContext
 // Matrix concurrency must disable it so real concurrent / compact execution works (TestScope + concurrency is
 // forbidden by TestBalloon and otherwise deadlocks). Sequential execution leaves the inherited scope intact.
 
-val concurrentMatrixDisablesTestScope by matrixSuite(execution = ExecutionMode.Concurrent(2)) {
+val concurrentMatrixDisablesTestScope by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent(2) }) {
     "concurrent execution disables the virtual-time TestScope" {
         coroutineContext[TestCoroutineScheduler].shouldBeNull()
     }
 }
 
-val sequentialMatrixKeepsTestScope by matrixSuite(execution = ExecutionMode.Sequential) {
+val sequentialMatrixKeepsTestScope by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     "sequential execution keeps the inherited TestScope" {
         coroutineContext[TestCoroutineScheduler].shouldNotBeNull()
     }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixDisabledTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixDisabledTest.kt
@@ -9,7 +9,7 @@ import kotlin.random.Random
 
 private fun explode(): Nothing = throw AssertionError("disabled matrix node executed")
 
-val disabledMatrix by matrixSuite(execution = ExecutionMode.Sequential) {
+val disabledMatrix by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     test("!disabled explicit test") { explode() }
 
     "!disabled bare test" { explode() }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixDslIntegrationTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixDslIntegrationTest.kt
@@ -8,7 +8,7 @@ import io.kotest.property.arbitrary.of
 // End-to-end DSL behaviour. All suites run Sequential so a trailing assertion test observes the
 // fully-accumulated counters (same pattern as `terminalLayerMatrix`). Names avoid "Report" so CI gates them.
 
-val matrixNestedDimensionsTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixNestedDimensionsTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var leaves = 0
     data("outer", listOf(1, 2, 3)) - {
         data("inner", listOf("a", "b")) test { leaves++ }
@@ -18,7 +18,7 @@ val matrixNestedDimensionsTest by matrixSuite(execution = ExecutionMode.Sequenti
     }
 }
 
-val matrixNestedPropertyAndDataTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixNestedPropertyAndDataTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var leaves = 0
     property("outer", Arb.of(1, 2), iterations = 2) - {
         data("inner", listOf(10, 20, 30)) test { leaves++ }
@@ -28,7 +28,7 @@ val matrixNestedPropertyAndDataTest by matrixSuite(execution = ExecutionMode.Seq
     }
 }
 
-val matrixSequenceLimitTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixSequenceLimitTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var count = 0
     data("seq", sequenceOf(1, 2, 3, 4, 5), limit = 2) test { count++ }
     "sequence limit caps the number of cases" {
@@ -41,7 +41,10 @@ val matrixSequenceLimitTest by matrixSuite(execution = ExecutionMode.Sequential)
 // discovery. So no integration suite for empty terminal data layers here — the matrix code may want to
 // skip registering an empty layer. Empty-source behaviour is covered at unit level in MatrixDataSourceTest.
 
-val matrixPropertyIterationsTest by matrixSuite(execution = ExecutionMode.Sequential, defaultPropertyIterations = 3) {
+val matrixPropertyIterationsTest by matrixSuite(matrixConfig {
+        execution = ExecutionMode.Sequential
+        defaultPropertyIterations = 3
+    }) {
     var seen = 0
     property("uses default", Arb.of(1, 2, 3)) test { seen++ }
     "a property without an explicit count uses the suite default" {
@@ -55,7 +58,7 @@ val matrixPropertyIterationsTest by matrixSuite(execution = ExecutionMode.Sequen
     }
 }
 
-val matrixDisabledLayerTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixDisabledLayerTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var ran = 0
     data("!disabled", listOf(1, 2)) test { ran++ }
     "a layer disabled by a leading bang runs no cases" {
@@ -63,7 +66,7 @@ val matrixDisabledLayerTest by matrixSuite(execution = ExecutionMode.Sequential)
     }
 }
 
-val matrixCompactPassingTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixCompactPassingTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     // A compact block whose every case passes must not throw.
     compact("all good") { report = CompactReport.AllCases } - {
         data("d", listOf(1, 2, 3)) test { it shouldBeGreaterThan 0 }
@@ -71,7 +74,7 @@ val matrixCompactPassingTest by matrixSuite(execution = ExecutionMode.Sequential
     }
 }
 
-val matrixCompactNestedTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixCompactNestedTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     compact("nested", ) { report = CompactReport.SummaryOnly } - {
         "group" - {
             property("p", Arb.of(2, 4, 6), iterations = 3) - { outer ->
@@ -81,7 +84,7 @@ val matrixCompactNestedTest by matrixSuite(execution = ExecutionMode.Sequential)
     }
 }
 
-val matrixCompactSharedPassingTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixCompactSharedPassingTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     compact("shared") {
         report = CompactReport.SummaryOnly
         concurrency = CompactConcurrency.Shared(4)
@@ -95,7 +98,7 @@ val matrixCompactSharedPassingTest by matrixSuite(execution = ExecutionMode.Sequ
 // Nameless `data`/`property` overloads: no leading layer name, no intermediate grouping node — the
 // per-case nodes are generated directly into the surrounding scope.
 
-val matrixNamelessNestedDataTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixNamelessNestedDataTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var leaves = 0
     data(listOf(1, 2, 3)) - {
         data(listOf("a", "b")) test { leaves++ }
@@ -105,7 +108,7 @@ val matrixNamelessNestedDataTest by matrixSuite(execution = ExecutionMode.Sequen
     }
 }
 
-val matrixNamelessPropertyOverDataTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixNamelessPropertyOverDataTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var leaves = 0
     property(Arb.of(1, 2), iterations = 2) - {
         data(listOf(10, 20, 30)) test { leaves++ }
@@ -115,7 +118,7 @@ val matrixNamelessPropertyOverDataTest by matrixSuite(execution = ExecutionMode.
     }
 }
 
-val matrixNamelessSequenceLimitTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixNamelessSequenceLimitTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var count = 0
     data(sequenceOf(1, 2, 3, 4, 5), limit = 2) test { count++ }
     "nameless sequence limit caps the number of cases" {
@@ -123,7 +126,7 @@ val matrixNamelessSequenceLimitTest by matrixSuite(execution = ExecutionMode.Seq
     }
 }
 
-val matrixNamelessCompactTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixNamelessCompactTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     compact("nameless compact") { report = CompactReport.AllCases } - {
         data(listOf(1, 2, 3)) test { it shouldBeGreaterThan 0 }
         property(Arb.of(2, 4, 6), iterations = 3) - {

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixFixtureCompactionTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixFixtureCompactionTest.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.shouldBe
 
 // ---- 1) Direct fixture: one fresh value per directly nested terminal test ----
 
-val fixtureDirectNoCompactTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val fixtureDirectNoCompactTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var calls = 0
     val seen = mutableListOf<Int>()
     fixture { ++calls } - {
@@ -24,7 +24,7 @@ val fixtureDirectNoCompactTest by matrixSuite(execution = ExecutionMode.Sequenti
     }
 }
 
-val fixtureDirectCompactTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val fixtureDirectCompactTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var calls = 0
     val seen = mutableListOf<Int>()
     compact("compacted") { report = CompactReport.SummaryOnly } - {
@@ -42,7 +42,7 @@ val fixtureDirectCompactTest by matrixSuite(execution = ExecutionMode.Sequential
 
 // ---- 2) Fixture as a suite: one value shared across its leaves ----
 
-val fixtureSuiteSharedNoCompactTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val fixtureSuiteSharedNoCompactTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var calls = 0
     val seen = mutableListOf<Int>()
     fixture { ++calls } - {
@@ -57,7 +57,7 @@ val fixtureSuiteSharedNoCompactTest by matrixSuite(execution = ExecutionMode.Seq
     }
 }
 
-val fixtureSuiteSharedCompactTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val fixtureSuiteSharedCompactTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var calls = 0
     val seen = mutableListOf<Int>()
     compact("compacted") { report = CompactReport.SummaryOnly } - {
@@ -76,7 +76,7 @@ val fixtureSuiteSharedCompactTest by matrixSuite(execution = ExecutionMode.Seque
 
 // ---- 3) Nested fixtures across a data layer: outer suite-fixture once, inner test-fixture per leaf ----
 
-val fixtureNestedNoCompactTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val fixtureNestedNoCompactTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var outer = 0
     var inner = 0
     val seen = mutableListOf<Pair<Int, Int>>()
@@ -96,7 +96,7 @@ val fixtureNestedNoCompactTest by matrixSuite(execution = ExecutionMode.Sequenti
     }
 }
 
-val fixtureNestedCompactTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val fixtureNestedCompactTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var outer = 0
     var inner = 0
     val seen = mutableListOf<Pair<Int, Int>>()
@@ -119,7 +119,7 @@ val fixtureNestedCompactTest by matrixSuite(execution = ExecutionMode.Sequential
 }
 
 
-val fixtureNestedCompactTestDifferentNesting by matrixSuite(execution = ExecutionMode.Sequential) {
+val fixtureNestedCompactTestDifferentNesting by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var outer = 0
     var inner = 0
     val seen = mutableListOf<Pair<Int, Int>>()
@@ -142,7 +142,7 @@ val fixtureNestedCompactTestDifferentNesting by matrixSuite(execution = Executio
 }
 
 
-val fixtureNestedCompactTestInnermostNesting by matrixSuite(execution = ExecutionMode.Sequential) {
+val fixtureNestedCompactTestInnermostNesting by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var outer = 0
     var inner = 0
     val seen = mutableListOf<Pair<Int, Int>>()

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixNestedRegistrationTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixNestedRegistrationTest.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.string.shouldContain
 // build window already closed) must throw loudly instead of being silently dropped. These suites capture
 // the scope and register after its build window, asserting the throw — so they pass.
 
-val nestedRegistrationRealTreeTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val nestedRegistrationRealTreeTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     val scope = this // the root MatrixSuiteScope; open only during this build body
     "registering on a matrix scope while a test runs throws" {
         // we are now executing a test body — scope's build window is closed
@@ -17,7 +17,7 @@ val nestedRegistrationRealTreeTest by matrixSuite(execution = ExecutionMode.Sequ
     }
 }
 
-val nestedRegistrationRealTreeHappyPathTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val nestedRegistrationRealTreeHappyPathTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var innerRan = false
     "outer" - {
         "inner" { innerRan = true }
@@ -27,7 +27,7 @@ val nestedRegistrationRealTreeHappyPathTest by matrixSuite(execution = Execution
     }
 }
 
-val nestedRegistrationCompactTest by matrixSuite(execution = ExecutionMode.Sequential) {
+val nestedRegistrationCompactTest by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     var planningScope: CompactScope? = null
     compact("c") { report = CompactReport.SummaryOnly } - {
         planningScope = this // the compact planning scope; open only during planning

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixPerScopeConfigTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixPerScopeConfigTest.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.coroutineContext
 // execution (etc.) for that subtree. Verified via the concurrency→testScope-disable behavior: a Concurrent override
 // drops the inherited virtual-time TestScope, a Sequential sibling keeps it. Unset fields inherit the enclosing scope.
 
-val perSuiteMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+val perSuiteMatrixConfig by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     testSuite("concurrent group", matrixConfig { execution = ExecutionMode.Concurrent(2) }) {
         "the concurrent override disables the virtual-time TestScope" {
             coroutineContext[TestCoroutineScheduler].shouldBeNull()
@@ -24,13 +24,13 @@ val perSuiteMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
     }
 }
 
-val perTestMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+val perTestMatrixConfig by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     test("concurrent test", matrixConfig { execution = ExecutionMode.Concurrent(2) }) {
         coroutineContext[TestCoroutineScheduler].shouldBeNull()
     }
 }
 
-val freeSpecMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+val freeSpecMatrixConfig by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     "concurrent group"(matrixConfig { execution = ExecutionMode.Concurrent(2) }) - {
         "freespec group override disables the TestScope" {
             coroutineContext[TestCoroutineScheduler].shouldBeNull()
@@ -43,7 +43,7 @@ val freeSpecMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
 
 // Concurrency must win over a user-supplied testConfig: even if the user's testConfig enables a TestScope,
 // the matrix concurrency override disables it (testScope(false) is chained innermost, so it wins).
-val concurrencyOverridesUserTestScope by matrixSuite(execution = ExecutionMode.Sequential) {
+val concurrencyOverridesUserTestScope by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     testSuite(
         "forced concurrent",
         matrixConfig {
@@ -58,7 +58,7 @@ val concurrencyOverridesUserTestScope by matrixSuite(execution = ExecutionMode.S
 }
 
 // Fixture-scope test/testSuite (and freespec) take matrixConfig the same way, and still inject the fixture value.
-val fixtureMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+val fixtureMatrixConfig by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     fixture { 42 } - {
         testSuite("concurrent fixture group", matrixConfig { execution = ExecutionMode.Concurrent(2) }) { value ->
             "fixture suite override disables the TestScope and still sees the fixture" {
@@ -79,7 +79,7 @@ val fixtureMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
 // The testConfig-only shorthand still wraps matrixConfig and applies aroundAll exactly once.
 private var shorthandAroundAllRuns = 0
 
-val testConfigShorthandStillAppliesOnce by matrixSuite(execution = ExecutionMode.Sequential) {
+val testConfigShorthandStillAppliesOnce by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     testSuite("g", testConfig = TestConfig.aroundAll { shorthandAroundAllRuns++; it() }) {
         data(listOf(1, 2, 3)) test { }
     }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixPerScopeConfigTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixPerScopeConfigTest.kt
@@ -1,0 +1,89 @@
+package at.asitplus.testballoon.matrix
+
+import de.infix.testBalloon.framework.core.TestConfig
+import de.infix.testBalloon.framework.core.aroundAll
+import de.infix.testBalloon.framework.core.testScope
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlin.coroutines.coroutineContext
+
+// Per-scope matrix config: `test` / `testSuite` and their FreeSpec forms accept `matrixConfig { … }` to override
+// execution (etc.) for that subtree. Verified via the concurrency→testScope-disable behavior: a Concurrent override
+// drops the inherited virtual-time TestScope, a Sequential sibling keeps it. Unset fields inherit the enclosing scope.
+
+val perSuiteMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+    testSuite("concurrent group", matrixConfig { execution = ExecutionMode.Concurrent(2) }) {
+        "the concurrent override disables the virtual-time TestScope" {
+            coroutineContext[TestCoroutineScheduler].shouldBeNull()
+        }
+    }
+    "a sequential sibling keeps the inherited TestScope" {
+        coroutineContext[TestCoroutineScheduler].shouldNotBeNull()
+    }
+}
+
+val perTestMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+    test("concurrent test", matrixConfig { execution = ExecutionMode.Concurrent(2) }) {
+        coroutineContext[TestCoroutineScheduler].shouldBeNull()
+    }
+}
+
+val freeSpecMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+    "concurrent group"(matrixConfig { execution = ExecutionMode.Concurrent(2) }) - {
+        "freespec group override disables the TestScope" {
+            coroutineContext[TestCoroutineScheduler].shouldBeNull()
+        }
+    }
+    "freespec test override"(matrixConfig { execution = ExecutionMode.Concurrent(2) }) {
+        coroutineContext[TestCoroutineScheduler].shouldBeNull()
+    }
+}
+
+// Concurrency must win over a user-supplied testConfig: even if the user's testConfig enables a TestScope,
+// the matrix concurrency override disables it (testScope(false) is chained innermost, so it wins).
+val concurrencyOverridesUserTestScope by matrixSuite(execution = ExecutionMode.Sequential) {
+    testSuite(
+        "forced concurrent",
+        matrixConfig {
+            execution = ExecutionMode.Concurrent(2)
+            testConfig = TestConfig.testScope(isEnabled = true)
+        },
+    ) {
+        "concurrency disables the TestScope even when the user's testConfig enabled it" {
+            coroutineContext[TestCoroutineScheduler].shouldBeNull()
+        }
+    }
+}
+
+// Fixture-scope test/testSuite (and freespec) take matrixConfig the same way, and still inject the fixture value.
+val fixtureMatrixConfig by matrixSuite(execution = ExecutionMode.Sequential) {
+    fixture { 42 } - {
+        testSuite("concurrent fixture group", matrixConfig { execution = ExecutionMode.Concurrent(2) }) { value ->
+            "fixture suite override disables the TestScope and still sees the fixture" {
+                coroutineContext[TestCoroutineScheduler].shouldBeNull()
+                value shouldBe 42
+            }
+        }
+        test("concurrent fixture test", matrixConfig { execution = ExecutionMode.Concurrent(2) }) { value ->
+            coroutineContext[TestCoroutineScheduler].shouldBeNull()
+            value shouldBe 42
+        }
+        "freespec fixture group"(matrixConfig { execution = ExecutionMode.Concurrent(2) }) - { value ->
+            "child sees the fixture under a concurrent override" { value shouldBe 42 }
+        }
+    }
+}
+
+// The testConfig-only shorthand still wraps matrixConfig and applies aroundAll exactly once.
+private var shorthandAroundAllRuns = 0
+
+val testConfigShorthandStillAppliesOnce by matrixSuite(execution = ExecutionMode.Sequential) {
+    testSuite("g", testConfig = TestConfig.aroundAll { shorthandAroundAllRuns++; it() }) {
+        data(listOf(1, 2, 3)) test { }
+    }
+    "the testConfig shorthand aroundAll wraps its suite once" {
+        shorthandAroundAllRuns shouldBe 1
+    }
+}

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTerminalLayerTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTerminalLayerTest.kt
@@ -5,10 +5,10 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.of
 
-val terminalLayerMatrix by matrixSuite(
-    execution = ExecutionMode.Sequential,
-    defaultPropertyIterations = 2,
-) {
+val terminalLayerMatrix by matrixSuite(matrixConfig {
+        execution = ExecutionMode.Sequential
+        defaultPropertyIterations = 2
+    }) {
     data("terminal iterable data", listOf(1, 2)) test { row ->
         row shouldBeGreaterThan 0
     }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTest.kt
@@ -13,7 +13,7 @@ import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 
 
-val matrixReport by matrixSuite(execution = ExecutionMode.Concurrent(12)) {
+val matrixReport by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent(12) }) {
     data("outer", listOf(1, 6, Random.nextBytes(300))) - { num ->
         property("layer 1", Arb.boolean(), iterations = 50) - { bool ->
             compact("whatever") {
@@ -103,7 +103,7 @@ val matrix2Report by matrixSuite {
     }
 }
 
-val hugeMatrixReport by matrixSuite(execution = ExecutionMode.Concurrent()) {
+val hugeMatrixReport by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent() }) {
     property("property layer 2", Arb.uLong(), iterations = 100) - { uLong ->
         compact("compacted") {
             report = CompactReport.AllCases
@@ -117,7 +117,7 @@ val hugeMatrixReport by matrixSuite(execution = ExecutionMode.Concurrent()) {
     }
 }
 
-val fixtureMatrixReport by matrixSuite(execution = ExecutionMode.Concurrent()) {
+val fixtureMatrixReport by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent() }) {
     property("property layer 1", Arb.uLong(), iterations = 100) - { uLong ->
         fixture { Random.nextBytes(16) } - {
             "pinned randomness 1" - { num ->
@@ -159,7 +159,7 @@ val fixtureMatrixReport by matrixSuite(execution = ExecutionMode.Concurrent()) {
 }
 
 
-val combinedFeaturesReport by matrixSuite(execution = ExecutionMode.Concurrent(12)) {
+val combinedFeaturesReport by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent(12) }) {
     fixture { Random.nextBytes(16) } - {
         "data, properties, fixtures, and compact reports" - { fixture ->
             data("multiplier", listOf(0, 1, 2, 3)) - { multiplier ->
@@ -178,7 +178,7 @@ val combinedFeaturesReport by matrixSuite(execution = ExecutionMode.Concurrent(1
 }
 
 
-val showcaseReport by matrixSuite(execution = ExecutionMode.Concurrent()) {
+val showcaseReport by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent() }) {
     property(
         "first",
         Arb.int(min = 1), iterations = 5, replay = Cases(seed = 5076239242101280184L, iter = 3L)

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTestConfigScopeTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTestConfigScopeTest.kt
@@ -10,10 +10,10 @@ import io.kotest.matchers.shouldBe
 
 private var suiteAroundAllRuns = 0
 
-val matrixSuiteTestConfigAppliesOnce by matrixSuite(
-    execution = ExecutionMode.Sequential,
-    testConfig = TestConfig.aroundAll { suiteAroundAllRuns++; it() },
-) {
+val matrixSuiteTestConfigAppliesOnce by matrixSuite(matrixConfig {
+        execution = ExecutionMode.Sequential
+        testConfig = TestConfig.aroundAll { suiteAroundAllRuns++; it() }
+    }) {
     data(listOf(1, 2, 3)) test { }
     "a suite-level aroundAll wraps the suite once, not once per data case" {
         suiteAroundAllRuns shouldBe 1
@@ -22,7 +22,7 @@ val matrixSuiteTestConfigAppliesOnce by matrixSuite(
 
 private var nestedSuiteAroundAllRuns = 0
 
-val matrixNestedTestSuiteTestConfigAppliesOnce by matrixSuite(execution = ExecutionMode.Sequential) {
+val matrixNestedTestSuiteTestConfigAppliesOnce by matrixSuite(matrixConfig { execution = ExecutionMode.Sequential }) {
     testSuite("group", testConfig = TestConfig.aroundAll { nestedSuiteAroundAllRuns++; it() }) {
         data(listOf(1, 2, 3)) test { }
     }

--- a/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTestConfigScopeTest.kt
+++ b/matrix/src/commonTest/kotlin/at/asitplus/testballoon/matrix/MatrixTestConfigScopeTest.kt
@@ -1,0 +1,32 @@
+package at.asitplus.testballoon.matrix
+
+import de.infix.testBalloon.framework.core.TestConfig
+import de.infix.testBalloon.framework.core.aroundAll
+import io.kotest.matchers.shouldBe
+
+// Regression: a TestConfig set at a matrix level must be applied ONCE at that level (testBalloon inherits it to
+// children structurally), not re-applied at every nested matrix level. The latter is what made a session's
+// `testScope` multiply into a deadlock and would make a suite-level `aroundAll` run once per data case.
+
+private var suiteAroundAllRuns = 0
+
+val matrixSuiteTestConfigAppliesOnce by matrixSuite(
+    execution = ExecutionMode.Sequential,
+    testConfig = TestConfig.aroundAll { suiteAroundAllRuns++; it() },
+) {
+    data(listOf(1, 2, 3)) test { }
+    "a suite-level aroundAll wraps the suite once, not once per data case" {
+        suiteAroundAllRuns shouldBe 1
+    }
+}
+
+private var nestedSuiteAroundAllRuns = 0
+
+val matrixNestedTestSuiteTestConfigAppliesOnce by matrixSuite(execution = ExecutionMode.Sequential) {
+    testSuite("group", testConfig = TestConfig.aroundAll { nestedSuiteAroundAllRuns++; it() }) {
+        data(listOf(1, 2, 3)) test { }
+    }
+    "a nested testSuite-level aroundAll wraps that suite once, not once per data case" {
+        nestedSuiteAroundAllRuns shouldBe 1
+    }
+}


### PR DESCRIPTION
* **Matrix testing:**
    * **Breaking:** `matrixSuite(...)` now takes its configuration as a single `matrixConfig { … }` argument instead of
      many named parameters:
      `val Suite by matrixSuite(matrixConfig { execution = ExecutionMode.Concurrent(8); defaultCompactReport = … }) { … }`
      (or `val Suite by matrixSuite { … }` with no config). This matches the per-scope `test` / `testSuite` config form.
      Migration: wrap the former named arguments in `matrixConfig { … }`, turning `name = value, …` into
      `name = value` lines.
    * Why: the TestBalloon compiler plugin (observed on `1.0.0-K2.4.0-Beta2`) silently fails to discover a top-level
      `val x by matrixSuite(...)` when the call passes named arguments **out of declaration order** with non-constant
      values — Kotlin 2.4 lowers such a call into a temporary-introducing block, and the plugin's
      `visitPropertyNew` only recognizes a plain `IrCall`, so the suite is dropped from discovery ("did not discover any
      tests") or its `qualifiedPropertyName` is never injected. Collapsing the parameters into one `matrixConfig`
      argument keeps the call site a shape the plugin always discovers, regardless of how the config fields are ordered.
      (A standalone reproduction for the upstream framework bug lives in `repro-consumer/`.)
    * Fix `TestConfig` being re-applied at every nested matrix level. The base config (a session config captured via
      `MatrixTestDefaults { }`, or a suite-level `testConfig`) is now applied once at the level it's set and inherited
      to children by TestBalloon, instead of being re-chained at each nested data/property case, suite, and test. This
      caused stateful wrappers to multiply — most visibly a session `testScope` combined with `execution = Concurrent`
      deadlocking or aborting discovery ("did not discover any tests"), and a suite-level `aroundAll` running once per
      case. Removed the internal `MatrixTestDefaults.testSessionConfig` capture (TestBalloon already propagates the
      session config). Per-element `testConfig` on `test` / `testSuite` / `matrixSuite` (incl. FreeSpec forms) still
      applies exactly once, so `aroundAll` / `aroundEach` behave as expected.
    * `test` / `testSuite` and their FreeSpec `"name"(…)` forms now accept a full matrix config via a new
      `matrixConfig { … }` value (e.g. `testSuite("g", matrixConfig { execution = ExecutionMode.Concurrent(8) }) { }`,
      `"g"(matrixConfig { … }) - { }`). Unset fields inherit the enclosing scope; `testConfig` is one of the fields, so
      the existing `testConfig =` forms are now thin wrappers around `matrixConfig { testConfig = … }`. Lets you set
      per-subtree concurrency (and have it auto-disable the `TestScope`) without a separate `matrixSuite`. Also
      available on the fixture-scope `test` / `testSuite` (and their FreeSpec forms). When a `matrixConfig` sets both
      `execution = Concurrent(…)` and a `testConfig` that enables a `TestScope`, the concurrency disable wins.
    * Matrix concurrency now auto-disables TestBalloon's virtual-time `TestScope`: any `ExecutionMode.Concurrent`
      layer/suite and every `compact` block (both execute on real dispatchers) chain `testScope(isEnabled = false)`,
      so concurrent/compact matrices run even under a session that enables `testScope` (the default) — no manual
      `testScope(isEnabled = false)` needed. Sequential execution leaves the inherited `TestScope` intact.